### PR TITLE
Fix test failure against Twisted 14.0.0 (and likely earlier).

### DIFF
--- a/nevow/test/test_appserver.py
+++ b/nevow/test/test_appserver.py
@@ -153,10 +153,10 @@ class Logging(testutil.TestCase):
             def renderHTTP(self, ctx):
                 return "boring"
         self.site = appserver.NevowSite(Res1())
+        self.site.startFactory()
+        self.addCleanup(self.site.stopFactory)
         self.site.logFile = StringIO()
 
-    def tearDown(self):
-        del self.site
 
     def renderResource(self, path):
         """@todo: share me"""
@@ -188,8 +188,11 @@ class Logging(testutil.TestCase):
         logLines = proto.site.logFile.getvalue().splitlines()
         self.assertEquals(len(logLines), 1)
         # print proto.transport.data.getvalue()
-        self.assertEquals(logLines,
-                          ['fakeaddress2 - - faketime "GET /foo HTTP/1.0" 200 6 "fakerefer" "fakeagent"'])
+        self.assertEquals(
+            logLines,
+            ['"fakeaddress2" - - faketime "GET /foo HTTP/1.0" 200 6 '
+             '"fakerefer" "fakeagent"'])
+
 
     def test_newStyle(self):
         class FakeLogger(object):


### PR DESCRIPTION
Start the factory before trying to use it.  This is how factories are actually driven.

Also change the literal log string the test asserts against.  The formatting code is in
Twisted and Twisted decided to change the specific way the formatting was done.  Too bad,
Nevow.

Fixes #29
