### PR TITLE
Convince bdist_wheel to package the nevow_widget dropin file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,12 @@ for (dirpath, dirnames, filenames) in os.walk("doc"):
         thesedocs.append(os.path.join(dirpath, fname))
     data_files.append((dirpath, thesedocs))
 
-data_files.append((os.path.join('twisted', 'plugins'), [os.path.join('twisted', 'plugins', 'nevow_widget.py')]))
-
 setup(
     name='Nevow',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     packages=find_packages(),
+    py_modules=["twisted.plugins.nevow_widget"],
     include_package_data=True,
     author='Divmod, Inc.',
     author_email='support@divmod.org',


### PR DESCRIPTION
Fixes #35

I should have done this after #34, no doubt.  Still, I manually verified that sdist and bdist_wheel both produce packages containing nevow_widget.py with the change in this branch.  I also actually installed both packages and ran the test suite with both of them.  The results are the same except for some skips due to _other_ files that get left out.  But they're examples that I'm not as concerned about.
