### PR TITLE
Explain requirements 43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,43 @@ python:
   - "2.7"
 
 env:
-  # Test various kinds of Nevow installations.  See below for the precise
-  # meaning of each mode.
+  #
+  # The `MODE` environment variable will control the kind of Nevow installation
+  # being tested.  See below for the precise meaning of each mode.
+  #
+  #
+  # The `TWISTED` environment variable will give a (shell expression which
+  # evaluates to) a Twisted requirement string which can be used to select a
+  # version of Twisted to install.  This lets the test suite run against
+  # multiple versions of Twisted.  As a cop out, this configuration only
+  # actually tests the minimum supported version of Twisted, the latest release
+  # of Twisted, and the master@HEAD version of Twisted.
+  #
+  # For expediency, all combinations of `MODE` and `TWISTED` are not tested.
+  # The "wheel" MODE is (arbitrarily) selected and all values of `TWISTED` are
+  # exercised in that mode.
+  #
   - MODE=inplace
   - MODE=source
   - MODE=sdist
   - MODE=wheel
 
+  - MODE=wheel
+    TWISTED='echo twisted'
+  - MODE=wheel
+    TWISTED='echo -n "twisted=="; python -c "from setup import _MINIMUM_TWISTED_VERSION; print _MINIMUM_TWISTED_VERSION"'
+  - MODE=wheel
+    TWISTED='echo git+https://github.com/twisted/twisted.git'
+
+
 install:
   - "python setup.py --version"
+  - |
+    # If appropriate, install a specific version of Twisted.
+    if [ -v TWISTED ]; then
+        pip install "$(eval ${TWISTED})"
+    fi
+
   - |
     if [ "${MODE}" == "wheel" ]; then
         # Build and install a wheel of Nevow.

--- a/nevow/test/test_appserver.py
+++ b/nevow/test/test_appserver.py
@@ -8,10 +8,10 @@ Tests for L{nevow.appserver}.
 from zope.interface import implements
 
 from cStringIO import StringIO
+from shlex import split
 
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import Deferred
-
 
 from nevow import inevow
 from nevow import appserver
@@ -208,11 +208,10 @@ class Logging(testutil.TestCase):
         proto = self.renderResource('/foo')
         logLines = proto.site.logFile.getvalue().splitlines()
         self.assertEquals(len(logLines), 1)
-        # print proto.transport.data.getvalue()
-        self.assertEquals(
-            logLines,
-            ['"fakeaddress2" - - faketime "GET /foo HTTP/1.0" 200 6 '
-             '"fakerefer" "fakeagent"'])
+        self.assertEqual(
+            split(logLines[0]),
+            ['fakeaddress2', '-', '-', 'faketime', 'GET /foo HTTP/1.0', '200', '6',
+             'fakerefer', 'fakeagent'])
 
 
     def test_newStyle(self):

--- a/setup.py
+++ b/setup.py
@@ -19,85 +19,86 @@ for (dirpath, dirnames, filenames) in os.walk("doc"):
         thesedocs.append(os.path.join(dirpath, fname))
     data_files.append((dirpath, thesedocs))
 
-setup(
-    name='Nevow',
-    version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
-    packages=find_packages(),
-    py_modules=["twisted.plugins.nevow_widget"],
-    include_package_data=True,
-    author='Divmod, Inc.',
-    author_email='support@divmod.org',
-    maintainer='Twisted Matrix Labs',
-    maintainer_email='twisted-web@twistedmatrix.com',
-    description='Web Application Construction Kit',
-    url='https://github.com/twisted/nevow',
-    license='MIT',
-    platforms=["any"],
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Framework :: Twisted",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python",
-        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
-        "Topic :: Software Development :: Libraries",
-        ],
-    scripts=['bin/nevow-xmlgettext', 'bin/nit'],
-    data_files=data_files,
-    package_data={
-            'formless': [
-                'freeform-default.css'
-                ],
-            'nevow': [
-                'Canvas.swf',
-                '*.css',
-                '*.js',
-                'css/*.css',
-                'css/Nevow/*.css',
-                'css/Nevow/TagLibrary/*.css',
-                'js/Divmod/*.js',
-                'js/Nevow/*.js',
-                'js/Nevow/Test/*.js',
-                'js/Nevow/Athena/Tests/*.js',
-                'js/Divmod/Runtime/*.js',
-                'js/Nevow/Athena/*.js',
-                'js/Nevow/TagLibrary/*.js',
-                'js/Divmod/Test/*.js',
-                'js/PythonTestSupport/*.js',
-                ],
-            'nevow.athena_private': [
-                '*.png'
-                ],
-            'nevow.taglibrary': [
-                '*.css',
-                '*.js'
-                ],
-            'nevow.livetrial': [
-                '*.css',
-                '*.js'
-                ],
-            'nevow.test': [
-                '*.js'
-                ],
-            'nevow.test.test_package.Foo': [
-                '*.js'
-                ],
-            'nevow.test.test_package.Foo.Baz': [
-                '*.js'
-                ],
-            },
-    install_requires=[
-        # Nevow builds on Twisted Web's HTTP server.  It also uses various
-        # other generally useful pieces of Twisted (such as its logging system,
-        # not to mention reactors and Deferreds).
-        #
-        # That dependency will be expressed here with a version range including
-        # only those versions of Twisted against which Nevow's continuous
-        # integration system is configured to actually test.  This ensures any
-        # combination allowed by this declaration has been tested and found to
-        # work.
-        "twisted>=13.0",
-        ],
-    zip_safe=False,
-)
+if __name__ == "__main__":
+    setup(
+        name='Nevow',
+        version=versioneer.get_version(),
+        cmdclass=versioneer.get_cmdclass(),
+        packages=find_packages(),
+        py_modules=["twisted.plugins.nevow_widget"],
+        include_package_data=True,
+        author='Divmod, Inc.',
+        author_email='support@divmod.org',
+        maintainer='Twisted Matrix Labs',
+        maintainer_email='twisted-web@twistedmatrix.com',
+        description='Web Application Construction Kit',
+        url='https://github.com/twisted/nevow',
+        license='MIT',
+        platforms=["any"],
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Framework :: Twisted",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python",
+            "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+            "Topic :: Software Development :: Libraries",
+            ],
+        scripts=['bin/nevow-xmlgettext', 'bin/nit'],
+        data_files=data_files,
+        package_data={
+                'formless': [
+                    'freeform-default.css'
+                    ],
+                'nevow': [
+                    'Canvas.swf',
+                    '*.css',
+                    '*.js',
+                    'css/*.css',
+                    'css/Nevow/*.css',
+                    'css/Nevow/TagLibrary/*.css',
+                    'js/Divmod/*.js',
+                    'js/Nevow/*.js',
+                    'js/Nevow/Test/*.js',
+                    'js/Nevow/Athena/Tests/*.js',
+                    'js/Divmod/Runtime/*.js',
+                    'js/Nevow/Athena/*.js',
+                    'js/Nevow/TagLibrary/*.js',
+                    'js/Divmod/Test/*.js',
+                    'js/PythonTestSupport/*.js',
+                    ],
+                'nevow.athena_private': [
+                    '*.png'
+                    ],
+                'nevow.taglibrary': [
+                    '*.css',
+                    '*.js'
+                    ],
+                'nevow.livetrial': [
+                    '*.css',
+                    '*.js'
+                    ],
+                'nevow.test': [
+                    '*.js'
+                    ],
+                'nevow.test.test_package.Foo': [
+                    '*.js'
+                    ],
+                'nevow.test.test_package.Foo.Baz': [
+                    '*.js'
+                    ],
+                },
+        install_requires=[
+            # Nevow builds on Twisted Web's HTTP server.  It also uses various
+            # other generally useful pieces of Twisted (such as its logging system,
+            # not to mention reactors and Deferreds).
+            #
+            # That dependency will be expressed here with a version range including
+            # only those versions of Twisted against which Nevow's continuous
+            # integration system is configured to actually test.  This ensures any
+            # combination allowed by this declaration has been tested and found to
+            # work.
+            "twisted>=13.0",
+            ],
+        zip_safe=False,
+    )

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,15 @@ setup(
                 ],
             },
     install_requires=[
+        # Nevow builds on Twisted Web's HTTP server.  It also uses various
+        # other generally useful pieces of Twisted (such as its logging system,
+        # not to mention reactors and Deferreds).
+        #
+        # That dependency will be expressed here with a version range including
+        # only those versions of Twisted against which Nevow's continuous
+        # integration system is configured to actually test.  This ensures any
+        # combination allowed by this declaration has been tested and found to
+        # work.
         "twisted>=13.0",
         ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ versioneer.versionfile_build = 'nevow/_version.py'
 versioneer.tag_prefix = 'nevow-'
 versioneer.parentdir_prefix = 'Nevow-'
 
+# For the convenience of the travis configuration, make this information
+# particularly easy to find.  See .travis.yml.
+_MINIMUM_TWISTED_VERSION = "13.0"
+
 from setuptools import setup, find_packages
 
 import os
@@ -98,7 +102,7 @@ if __name__ == "__main__":
             # integration system is configured to actually test.  This ensures any
             # combination allowed by this declaration has been tested and found to
             # work.
-            "twisted>=13.0",
+            "twisted>=" + _MINIMUM_TWISTED_VERSION,
             ],
         zip_safe=False,
     )


### PR DESCRIPTION
Fixes #43

This branch is constructed so as to be most easily reviewed changeset by changeset.

Note that beyond the (sort of obvious) comment added to setup.py this tweaks the travis configuration to run the test suite three extra times - once for each of the three versions of Twisted (Nevow's only declared dependency) that it is statically obvious Nevow might be used with.
