### PR TITLE
Serialize tag attributes in a stable order

### DIFF
--- a/formless/test/test_freeform.py
+++ b/formless/test/test_freeform.py
@@ -82,7 +82,7 @@ class Complete(Base):
             self.assertSubstring('freeform_post!!foo', val)
             self.assertSubstring('foo', val)
             self.assertSubstring('type="text"', val)
-            self.assertSubstring('<input type="submit"', val)
+            self.assertSubstring('<input name="change" type="submit"', val)
         return self.renderForms(dumb).addCallback(doasserts)
 
 
@@ -138,7 +138,7 @@ class BuildingBlocksTest(Base):
         renderer = iformless.IBindingRenderer(binding)
         def later(val):
             self.assertSubstring('<form ', val)
-            self.assertSubstring('<input type="submit"', val)
+            self.assertSubstring('<input name="change" type="submit"', val)
             self.assertSubstring('name="goodbye"', val)
             self.assertSubstring('Goodbye', val)
             self.assertSubstring('Goodbye cruel world', val)
@@ -549,7 +549,7 @@ class TestCharsetDetectionSupport(Base):
         impl = Impl()
         ctx = self.setupContext()
         def later(val):
-            self.assertIn('<input type="hidden" name="_charset_" />', val)
+            self.assertIn('<input name="_charset_" type="hidden" />', val)
             self.assertIn('accept-charset="utf-8"', val)
         return self.renderForms(impl, ctx).addCallback(later)
 
@@ -566,7 +566,7 @@ class TestCharsetDetectionSupport(Base):
         impl = Impl()
         ctx = self.setupContext()
         def later(val):
-            self.assertIn('<input type="hidden" name="_charset_" />', val)
+            self.assertIn('<input name="_charset_" type="hidden" />', val)
             self.assertIn('accept-charset="utf-8"', val)
         return self.renderForms(impl, ctx).addCallback(later)
 
@@ -584,7 +584,7 @@ class TestCharsetDetectionSupport(Base):
         impl = Impl()
         ctx = self.setupContext()
         def later(val):
-            self.assertIn('<input type="hidden" name="_charset_" />', val)
+            self.assertIn('<input name="_charset_" type="hidden" />', val)
             self.assertIn('accept-charset="utf-8"', val)
         return self.renderForms(impl, ctx).addCallback(later)
 

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -274,7 +274,7 @@ def _flatten(request, root, slotData, renderFactory, inAttribute, inXML):
                     else:
                         tagName = str(root.tagName)
                     yield tagName
-                    for k, v in root.attributes.iteritems():
+                    for k, v in sorted(root.attributes.iteritems()):
                         if isinstance(k, unicode):
                             k = k.encode('ascii')
                         yield " " + k + "=\""

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -111,7 +111,7 @@ def TagSerializer(original, context, contextIsMine=False):
     yield '<%s' % original.tagName
     if original.attributes:
         attribContext = WovenContext(parent=context, precompile=context.precompile, isAttrib=True)
-        for (k, v) in original.attributes.iteritems():
+        for (k, v) in sorted(original.attributes.iteritems()):
             if v is None:
                 continue
             yield ' %s="' % k


### PR DESCRIPTION
`attributes.iteritems()` doesn't have a guaranteed order and depends on the underlying implementation.
This caused some tests to fail under specific circumstances because they were expecting a specific order which wasn't the one returned in this case.

This fix makes attributes serialization stable, and fix some tests which were expecting a different order than the new, stable, one.

This is a proposed fix for #50, it seems to be sufficient but it's open for comment.