### PR TITLE
Implement Divmod runtime platforms for modern versions of Internet Explorer

### DIFF
--- a/nevow/js/Divmod/Base.js
+++ b/nevow/js/Divmod/Base.js
@@ -174,11 +174,10 @@ Divmod.Base.AdapterRegistry.methods(
             If no suitable adapter is found, throws NotFound.
 
         ***/
-        var args = Array.prototype.slice.call(arguments, 1);
         for (var i = 0; i < self.pairs.length; i++) {
             var pair = self.pairs[i];
-            if (pair[1].apply(self, args)) {
-                return pair[2].apply(self, args);
+            if (pair[1].apply(self, arguments)) {
+                return pair[2].apply(self, arguments);
             }
         }
         throw Divmod.Base.NotFound;

--- a/nevow/js/Divmod/Base.js
+++ b/nevow/js/Divmod/Base.js
@@ -174,10 +174,11 @@ Divmod.Base.AdapterRegistry.methods(
             If no suitable adapter is found, throws NotFound.
 
         ***/
+        var args = Array.prototype.slice.call(arguments, 1);
         for (var i = 0; i < self.pairs.length; i++) {
             var pair = self.pairs[i];
-            if (pair[1].apply(self, arguments)) {
-                return pair[2].apply(self, arguments);
+            if (pair[1].apply(self, args)) {
+                return pair[2].apply(self, args);
             }
         }
         throw Divmod.Base.NotFound;

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -526,8 +526,9 @@ Divmod.Runtime.Platform.methods(
         return null;
     },
 
+
     function makeHTTPRequest(self) {
-        throw new Error("makeHTTPRequest is unimplemented on " + self);
+        return new XMLHttpRequest();
     },
 
 
@@ -887,9 +888,6 @@ Divmod.Runtime.Firefox.methods(
         node.appendChild(document.importNode(doc.documentElement, true));
     },
 
-    function makeHTTPRequest(self) {
-        return new XMLHttpRequest();
-    },
 
     /**
      * Load the JavaScript module at the given URL.
@@ -1022,10 +1020,6 @@ Divmod.Runtime.WebKit.methods(
     function appendNodeContent(self, node, innerHTML) {
         var doc = self.parseXHTMLString(innerHTML);
         node.appendChild(document.importNode(doc.documentElement, true));
-    },
-
-    function makeHTTPRequest(self) {
-        return new XMLHttpRequest();
     });
 
 
@@ -1152,9 +1146,6 @@ Divmod.Runtime.InternetExplorerSemiModern.methods(
         node.innerHTML += doc.xml;
     },
 
-    function makeHTTPRequest(self) {
-        return new XMLHttpRequest();
-    },
 
     /**
      * Simulate importNode by rebuilding the node contents in a node created in
@@ -1308,10 +1299,6 @@ Divmod.Runtime.Opera.methods(
     function appendNodeContent(self, node, innerHTML) {
         var doc = self.parseXHTMLString(innerHTML);
         node.appendChild(document.importNode(doc.documentElement, true));
-    },
-
-    function makeHTTPRequest(self) {
-        return new XMLHttpRequest();
     });
 
 

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -205,8 +205,8 @@ Divmod.Runtime._makeSingleEventHandler = function _makeSingleEventHandler(
  * @ivar: The number of milliseconds by which to delay invocation of events
  *     registered with C{addLoadEvent}.
  */
-Divmod.Runtime.Platform.methods(
-    function __init__(self, name) {
+Divmod.Runtime.Platform.namedMethods({
+    '__init__': function (self, name) {
         self.name = name;
         self.attrNameToMangled = {};
         self._loadEventDelay = 1;
@@ -232,9 +232,8 @@ Divmod.Runtime.Platform.methods(
      *
      * @rtype: C{undefined}
      */
-    function connectSingleDOMEvent(
+    'connectSingleDOMEvent': function (
         self, domEventName, handlerObject, domNode, methodName) {
-
         Divmod.Runtime._eventHandlerObjects[
             handlerObject.__id__] = handlerObject;
 
@@ -260,7 +259,7 @@ Divmod.Runtime.Platform.methods(
      * @throw Error: If there is no node with an attribute which matches the
      * given value.
      */
-    function firstNodeByAttribute(self, root, attrName, attrValue) {
+    'firstNodeByAttribute': function (self, root, attrName, attrValue) {
         /* duplicate this here rather than adding an "onlyOne" arg to
            nodesByAttribute so adding an extra arg accidentally doesn't change
            it's behaviour if called directly
@@ -284,7 +283,7 @@ Divmod.Runtime.Platform.methods(
         return result;
     },
 
-    function nodesByAttribute(self, root, attrName, attrValue) {
+    'nodesByAttribute': function (self, root, attrName, attrValue) {
         var descend = Divmod.Runtime.Platform.DOM_DESCEND;
         var results = [];
         self.traverse(
@@ -298,7 +297,8 @@ Divmod.Runtime.Platform.methods(
         return results;
     },
 
-    function nodeByAttribute(self, root, attrName, attrValue, /* optional */ defaultNode) {
+    'nodeByAttribute': function (self, root, attrName, attrValue,
+                                 /* optional */ defaultNode) {
         var nodes = self.nodesByAttribute(root, attrName, attrValue);
         if (nodes.length > 1) {
             throw new Error("Found too many " + attrName + " = " + attrValue);
@@ -323,7 +323,7 @@ Divmod.Runtime.Platform.methods(
      *
      * @return: object with "x" and "y" slots
      */
-    function getEventCoords(self, event) {
+    'getEventCoords': function (self, event) {
         if(!event) {
             event = window.event;
         }
@@ -348,7 +348,7 @@ Divmod.Runtime.Platform.methods(
      *
      * @rtype: C{Number}
      */
-    function findPosX(self, node) {
+    'findPosX': function (self, node) {
         var curleft = 0;
         if (node.offsetParent) {
             while (node.offsetParent) {
@@ -367,7 +367,7 @@ Divmod.Runtime.Platform.methods(
      *
      * @rtype: C{Number}
      */
-    function findPosY(self, node) {
+    'findPosY': function (self, node) {
         var curtop = 0;
         if (node.offsetParent) {
             while (node.offsetParent) {
@@ -387,8 +387,8 @@ Divmod.Runtime.Platform.methods(
      *
      * @return: object with "w" and "h" attributes
      */
-    function getPageSize(self, /* optional */ win) {
-        var w, h
+    'getPageSize': function (self, /* optional */ win) {
+        var w, h;
         var theWindow = win || window;
 
         /* slightly modified version of code from
@@ -422,7 +422,7 @@ Divmod.Runtime.Platform.methods(
      *
      * @return: object with "w" and "h" attributes
      */
-    function getElementSize(self, e) {
+    'getElementSize': function (self, e) {
         var hidden = e.style.display == "none";
         if(hidden) {
             e.style.display = "";
@@ -437,7 +437,7 @@ Divmod.Runtime.Platform.methods(
     /**
      * Return all immediate children of C{root} that have tag name C{tagName}
      */
-    function getElementsByTagNameShallow(self, root, tagName) {
+    'getElementsByTagNameShallow': function (self, root, tagName) {
         var child, result = [];
         for(var i = 0; i < root.childNodes.length; i++) {
             child = root.childNodes[i];
@@ -455,7 +455,7 @@ Divmod.Runtime.Platform.methods(
      * L{Divmod.Runtime.Platform.setAttribute} when they encounter a
      * namespace-less attribute.
      */
-    function _mangleAttributeName(self, localName) {
+    '_mangleAttributeName': function (self, localName) {
         if(localName in self.attrNameToMangled) {
             return self.attrNameToMangled[localName];
         }
@@ -465,7 +465,8 @@ Divmod.Runtime.Platform.methods(
     /**
      * Reliably set the value for a node attribute.
      */
-    function setAttribute(self, node, localName, value, namespaceURI, namespaceIdentifier) {
+    'setAttribute': function (self, node, localName, value, namespaceURI,
+                              namespaceIdentifier) {
         if (namespaceURI === undefined && namespaceIdentifier === undefined) {
             localName = self._mangleAttributeName(localName);
         }
@@ -487,7 +488,8 @@ Divmod.Runtime.Platform.methods(
     /**
      * This is _the_way_ to get the value of an attribute off of node
      */
-    function getAttribute(self, node, localName, namespaceURI, namespaceIdentifier) {
+    'getAttribute': function (self, node, localName, namespaceURI,
+                              namespaceIdentifier) {
         if(namespaceURI == undefined && namespaceIdentifier == undefined) {
             localName = self._mangleAttributeName(localName);
         }
@@ -527,7 +529,7 @@ Divmod.Runtime.Platform.methods(
     },
 
 
-    function makeHTTPRequest(self) {
+    'makeHTTPRequest': function (self) {
         return new XMLHttpRequest();
     },
 
@@ -558,7 +560,8 @@ Divmod.Runtime.Platform.methods(
      * code of the response.  For example, 200 if successful.  The 'response'
      * will be a string, the text of the response.
      */
-    function getPage(self, url, /* optional */ args, action, headers, content, synchronous) {
+    'getPage': function (self, url, /* optional */ args, action, headers,
+                         content, synchronous) {
         // Fill out defaults.
         if (args === undefined) {
             args = [];
@@ -617,11 +620,11 @@ Divmod.Runtime.Platform.methods(
         return [req, d];
     },
 
-    function parseXHTMLString(self, s) {
+    'parseXHTMLString': function (self, s) {
         throw new Error("parseXHTMLString not implemented on " + self.name);
     },
 
-    function traverse(self, rootNode, visitor) {
+    'traverse': function (self, rootNode, visitor) {
         if(rootNode == undefined) {
             throw new Error("traverse() passed bad rootNode");
         }
@@ -659,7 +662,7 @@ Divmod.Runtime.Platform.methods(
      * @param node: A DOM node.
      * @param innerHTML The XHTML 1.0 string to append.
      */
-    function appendNodeContent(self, node, innerHTML) {
+    'appendNodeContent': function (self, node, innerHTML) {
         throw new Error("appendNodeContent not implemented on " + self.name);
     },
 
@@ -670,14 +673,14 @@ Divmod.Runtime.Platform.methods(
      * @param node: A DOM node.
      * @param innerHTML The XHTML 1.0 string to append.
      */
-    function setNodeContent(self, node, innerHTML) {
+    'setNodeContent': function (self, node, innerHTML) {
         while (node.childNodes.length) {
             node.removeChild(node.firstChild);
         }
         self.appendNodeContent(node, innerHTML);
     },
 
-    function loadScript(self, location) {
+    'loadScript': function (self, location) {
         // <script> tricks produce spectacularly bizarre behaviour in IE and
         // Safari doesn't support onerror, so we just use getPage/eval here.
         var req = Divmod.Runtime.theRuntime.getPage(location);
@@ -697,7 +700,7 @@ Divmod.Runtime.Platform.methods(
      *
      * @rtype: C{undefined}
      */
-    function loadStylesheet(self, location) {
+    'loadStylesheet': function (self, location) {
         var linkNode = document.createElement('link');
         linkNode.setAttribute('rel', 'stylesheet');
         linkNode.setAttribute('type', 'text/css');
@@ -714,7 +717,7 @@ Divmod.Runtime.Platform.methods(
      * @param deep: A boolean indicating whether children should be imported.
      * @returns: The imported Node.
      */
-    function importNode(self, node, deep) {
+    'importNode': function (self, node, deep) {
         return document.importNode(node, deep);
     },
 
@@ -726,7 +729,7 @@ Divmod.Runtime.Platform.methods(
      * is merely to allow for platfom-specific workarounds for certain edge
      * cases.
      */
-    function getElementByIdWithNode(self, node, id) {
+    'getElementByIdWithNode': function (self, node, id) {
         var foundNode = node.ownerDocument.getElementById(id);
         if (foundNode == null) {
             throw Divmod.Runtime.NodeNotFound('Node with id ' + id + ' not found');
@@ -741,7 +744,7 @@ Divmod.Runtime.Platform.methods(
      * this callable is not invoked directly in response to the DOM page load
      * event, but in a delayed call scheduled from that event.
      */
-    function addLoadEvent(self, callable) {
+    'addLoadEvent': function (self, callable) {
         var func = function() { setTimeout(callable, self._loadEventDelay); };
         Divmod.Base.addToCallStack(window, "onload", func, true);
     },
@@ -752,9 +755,10 @@ Divmod.Runtime.Platform.methods(
      * @param aWindow: The window object.
      * @param handler: The handler.
      */
-    function addBeforeUnloadHandler(self, aWindow, handler) {
+    'addBeforeUnloadHandler': function (self, aWindow, handler) {
         Divmod.Base.addToCallStack(aWindow, 'onbeforeunload', handler);
-    });
+    }
+});
 
 
 /**

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -74,7 +74,7 @@ Divmod.Runtime._getElementByIdWithDocument = function _getElementByIdWithDocumen
 
 
 /**
- * Get a document by ID, falling back to using L{_getElementByIdWithDocument}
+ * Get an element by ID, falling back to using L{_getElementByIdWithDocument}
  * if it's not found in its owner document.
  */
 Divmod.Runtime._getElementByIdWithNode = function _getElementByIdWithNode (node, doc, id) {

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -1052,6 +1052,29 @@ Divmod.Runtime.InternetExplorerModern.methods(
     },
 
 
+    function appendNodeContent(self, node, innerHTML) {
+        var head = document.getElementsByTagName('head').item(0);
+        var doc = self.parseXHTMLString(innerHTML);
+        var scripts = doc.getElementsByTagName('script');
+
+        while (scripts.length > 0) {
+            var oldScript = scripts[0].parentNode.removeChild(scripts[0]);
+            var src = oldScript.getAttribute('src');
+            var text = oldScript.text;
+            var script = document.createElement('script');
+            script.type = 'text/javascript';
+            if(src != '' && src != null){
+                script.src = src;
+            }
+            else if(text != '' && text != null){
+                script.text = text;
+            }
+            head.appendChild(script);
+        }
+        node.appendChild(document.importNode(doc.documentElement, true));
+    },
+
+
     function parseXHTMLString(self, s) {
         return self._xmlparser.parseXHTMLString(s);
     },

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -743,99 +743,8 @@ Divmod.Runtime.Spidermonkey.isThisTheOne = function isSpidermonkeyTheOne() {
 };
 
 
-Divmod.Runtime.XPathSupportingPlatform = Divmod.Runtime.Platform.subclass(
-    'Divmod.Runtime.XPathSupportingPlatform');
-Divmod.Runtime.XPathSupportingPlatform.methods(
-    function _nsResolver(self, prefix) {
-        var ns;
-        switch(prefix) {
-            case 'html':
-                ns = 'http://www.w3.org/1999/xhtml';
-                break;
-            case 'athena':
-                ns = 'http://divmod.org/ns/athena/0.7';
-                break;
-            default:
-                // this should never happen, but browsers still suck...
-                ns = null;
-        }
-        return ns;
-    },
 
-    function _xpathNodeByAttribute(self, attrName, attrValue) {
-        var upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        var lower = upper.toLowerCase();
-        return (
-            ".//*[@*[translate(name(),'" + upper + "', '" + lower + "')='" +
-            attrName + "']='" + attrValue + "'] | .[@*[translate(name(),'" +
-            upper + "', '" + lower + "')='" + attrName + "']='" + attrValue +
-            "']");
-    },
-
-    function firstNodeByAttribute(self, root, attrName, attrValue) {
-        /* duplicate this here rather than adding an "onlyOne" arg to
-           nodesByAttribute so adding an extra arg accidentally doesn't change
-           it's behaviour if called directly
-        */
-        var xpath = self._xpathNodeByAttribute(attrName, attrValue);
-        var node = document.evaluate(
-            xpath,
-            root,
-            null,
-            XPathResult.FIRST_ORDERED_NODE_TYPE,
-            null
-        ).singleNodeValue;
-        if (!node) {
-            throw Divmod.Runtime.NodeAttributeError(root, attrName, attrValue);
-        }
-        return node;
-    },
-
-    function nodeByAttribute(self, root, attrName, attrValue, /* optional */ defaultNode){
-        var xpath = self._xpathNodeByAttribute(attrName, attrValue);
-        var nodes = document.evaluate(
-            xpath,
-            root,
-            null,
-            XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-            null
-        );
-        if (nodes.snapshotLength > 1) {
-            throw new Error("Found too many " + attrName + " = " + attrValue);
-        }
-        else if (nodes.snapshotLength < 1) {
-            if (defaultNode === undefined) {
-                throw Divmod.Runtime.NodeAttributeError(root, attrName, attrValue);
-            }
-            else {
-                return defaultNode;
-            }
-        }
-        else {
-            var result = nodes.snapshotItem(0);
-            return result;
-        }
-    },
-
-    function nodesByAttribute(self, root, attrName, attrValue) {
-        var results = [];
-        var xpath = self._xpathNodeByAttribute(attrName, attrValue);
-        var nodes = document.evaluate(
-            xpath,
-            root,
-            null,
-            XPathResult.ORDERED_NODE_ITERATOR_TYPE,
-            null
-        );
-        var node = nodes.iterateNext();
-        while(node){
-            results.push(node);
-            node = nodes.iterateNext();
-        }
-        return results;
-    });
-
-Divmod.Runtime.Firefox = Divmod.Runtime.XPathSupportingPlatform.subclass(
+Divmod.Runtime.Firefox = Divmod.Runtime.Platform.subclass(
     'Divmod.Runtime.Firefox');
 
 Divmod.Runtime.Firefox.isThisTheOne = function isThisTheOne() {
@@ -1272,7 +1181,7 @@ Divmod.Runtime.InternetExplorerLegacy.methods(
     });
 
 
-Divmod.Runtime.Opera = Divmod.Runtime.XPathSupportingPlatform.subclass("Divmod.Runtime.Opera");
+Divmod.Runtime.Opera = Divmod.Runtime.Platform.subclass("Divmod.Runtime.Opera");
 
 Divmod.Runtime.Opera.isThisTheOne = function isThisTheOne() {
     try {

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -757,6 +757,14 @@ Divmod.Runtime.Platform.namedMethods({
      */
     'addBeforeUnloadHandler': function (self, aWindow, handler) {
         Divmod.Base.addToCallStack(aWindow, 'onbeforeunload', handler);
+    },
+
+
+    /**
+     * Is this a legacy browser?
+     */
+    'isLegacy': function (self) {
+        return false;
     }
 });
 
@@ -1225,6 +1233,11 @@ Divmod.Runtime.InternetExplorerLegacy.methods(
                                   "checked": "defaultChecked",
                                   "usemap": "useMap",
                                   "for": "htmlFor"};
+    },
+
+
+    function isLegacy(self) {
+        return true;
     },
 
 

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -836,6 +836,23 @@ Divmod.Runtime.Firefox.methods(
         return HTML_ELEMENT;
     },
 
+
+    function _nsResolver(self, prefix) {
+        var ns;
+        switch (prefix) {
+            case 'html':
+                ns = 'http://www.w3.org/1999/xhtml';
+                break;
+            case 'athena':
+                ns = 'http://divmod.org/ns/athena/0.7';
+                break;
+            default:
+                // this should never happen, but browsers still suck...
+                ns = null;
+        }
+        return ns;
+    },
+
     function parseXHTMLString(self, s) {
         return self._xmlparser.parseXHTMLString(s);
     },


### PR DESCRIPTION
Fixes #16.

Introduce new runtime platforms for all versions of Internet Explorer:

 * Legacy: 6 and 7
 * Semi-modern: 8 and 9
 * Modern: 10+

The `XPathSupportingPlatform` hack platform has also been removed in favour of the native APIs which are much faster and support modern HTML features now.

This PR also fixes the issue where some platform runtime methods with the same name as official browser APIs are leaked into the global object in some versions of IE and break feature detection (as well as having the wrong signature.)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/twisted/nevow/56)
<!-- Reviewable:end -->