### PR TITLE
Remove use of deprecated received_headers in NevowRequest.process.

### DIFF
--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -220,8 +220,9 @@ class NevowRequest(tpc.Componentized, server.Request):
         if self.method == 'POST':
             t = self.content.tell()
             self.content.seek(0)
-            self.fields = cgi.FieldStorage(self.content, self.received_headers,
-                                           environ={'REQUEST_METHOD': 'POST'})
+            self.fields = cgi.FieldStorage(
+                self.content, _DictHeaders(self.requestHeaders),
+                environ={'REQUEST_METHOD': 'POST'})
             self.content.seek(t)
 
         # get site from channel

--- a/nevow/test/test_appserver.py
+++ b/nevow/test/test_appserver.py
@@ -151,6 +151,26 @@ class TestSiteAndRequest(testutil.TestCase):
             request.finished, "Request was incorrectly marked as finished.")
 
 
+    def test_renderPOST(self):
+        """
+        A POST request with form data has the form data parsed into
+        C{request.fields}.
+        """
+        class Res(Render):
+            def renderHTTP(self, ctx):
+                return b''
+
+        s = appserver.NevowSite(Res())
+        r = appserver.NevowRequest(
+            testutil.FakeChannel(s), True)
+        r.method = b'POST'
+        r.path = b'/'
+        r.content = StringIO(b'foo=bar')
+        self.successResultOf(r.process())
+        self.assertEquals(r.fields[b'foo'].value, b'bar')
+
+
+
 from twisted.internet import protocol, address
 
 class FakeTransport(protocol.FileWrapper):


### PR DESCRIPTION
Fixes #53, for real.