### PR TITLE
Fix use of deprecated header attributes in nevow.compression.

### DIFF
--- a/nevow/compression.py
+++ b/nevow/compression.py
@@ -112,7 +112,7 @@ class CompressingRequestWrapper(_makeBase()):
         self._gzipFile = None
 
         # See setHeader docstring for more commentary.
-        self.underlying.headers.pop('content-length', None)
+        self.underlying.responseHeaders.removeHeader('content-length')
 
 
     def setHeader(self, name, value):

--- a/nevow/inevow.py
+++ b/nevow/inevow.py
@@ -312,7 +312,8 @@ class IRequest(IComponentized):
     @type args: A mapping of strings (the argument names) to lists of values.
                 i.e., ?foo=bar&foo=baz&quux=spam results in
                 {'foo': ['bar', 'baz'], 'quux': ['spam']}.
-    @ivar received_headers: All received headers.
+    @ivar requestHeaders: Header fields received in the request.
+    @ivar received_headers: DEPRECATED: All received headers.
     """
     method = Attribute("The HTTP method that was used.")
     uri = Attribute("The full URI that was requested (includes arguments).")
@@ -320,10 +321,15 @@ class IRequest(IComponentized):
     prepath = Attribute("Path segments that have already been handled.")
     postpath = Attribute("Path segments still to be handled.")
     args = Attribute("All of the arguments, including URL and POST arguments.")
-    received_headers = Attribute("All received headers.")
+    requestHeaders = Attribute(
+        "A L{http_headers.Headers} instance giving all received HTTP request "
+        "header fields.")
     deferred = Attribute("Fired once request processing is finished.")
     client = Attribute("The client that sent this request.")
     content = Attribute("File-like object containing the request body.")
+
+    # DEPRECATED:
+    received_headers = Attribute("DEPRECATED: All received headers.")
 
     # Methods for received request
     def getHeader(key):

--- a/nevow/test/test_athena.py
+++ b/nevow/test/test_athena.py
@@ -645,11 +645,11 @@ class UtilitiesTests(unittest.TestCase):
                        "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.0)"]
         for ua in supported:
             req = FakeRequest()
-            req.received_headers['user-agent'] = ua
+            req.requestHeaders.setRawHeaders('user-agent', [ua])
             self.assertTrue(page._supportedBrowser(req))
         for ua in unsupported:
             req = FakeRequest()
-            req.received_headers['user-agent'] = ua
+            req.requestHeaders.setRawHeaders('user-agent', [ua])
             self.assertFalse(page._supportedBrowser(req))
 
 
@@ -660,7 +660,9 @@ class UtilitiesTests(unittest.TestCase):
         ctx = WovenContext()
         page = athena.LivePage()
         req = FakeRequest()
-        req.received_headers['user-agent'] = "Mozilla/4.0 (compatible; MSIE 2.0; Windows NT 5.1)"
+        req.requestHeaders.setRawHeaders(
+            'user-agent',
+            ["Mozilla/4.0 (compatible; MSIE 2.0; Windows NT 5.1)"])
         ctx.remember(req, IRequest)
         d = renderPage(page, reqFactory=lambda: req)
         d.addCallback(

--- a/nevow/test/test_compression.py
+++ b/nevow/test/test_compression.py
@@ -133,7 +133,7 @@ class RequestWrapperTests(TestCase):
         Attributes on the wrapper should be forwarded to the underlying
         request.
         """
-        attributes = ['method', 'uri', 'path', 'args', 'received_headers']
+        attributes = ['method', 'uri', 'path', 'args', 'requestHeaders']
         for attrName in attributes:
             self.assertIdentical(getattr(self.wrapper, attrName),
                                  getattr(self.request, attrName))

--- a/nevow/test/test_compression.py
+++ b/nevow/test/test_compression.py
@@ -153,20 +153,25 @@ class RequestWrapperTests(TestCase):
         """
         Content-Length header should be discarded when compression is in use.
         """
-        self.assertNotIn('content-length', self.request.headers)
+        self.assertFalse(
+            self.request.responseHeaders.hasHeader('content-length'))
         self.wrapper.setHeader('content-length', 1234)
-        self.assertNotIn('content-length', self.request.headers)
+        self.assertFalse(
+            self.request.responseHeaders.hasHeader('content-length'))
 
         self.request.setHeader('content-length', 1234)
         self.wrapper = CompressingRequestWrapper(self.request)
-        self.assertNotIn('content-length', self.request.headers)
+        self.assertFalse(
+            self.request.responseHeaders.hasHeader('content-length'))
 
 
     def test_responseHeaders(self):
         """
         Content-Encoding header should be set appropriately.
         """
-        self.assertEqual(self.request.headers['content-encoding'], 'gzip')
+        self.assertEqual(
+            self.request.responseHeaders.getRawHeaders('content-encoding'),
+            ['gzip'])
 
 
     def test_lazySetup(self):
@@ -452,14 +457,17 @@ class ResourceWrapper(TestCase):
         """
         self.assertFalse(self.wrapped.canCompress(self.request))
 
-        self.request.received_headers['accept-encoding'] = 'foo;q=1.0, bar;q=0.5, baz'
+        self.request.requestHeaders.setRawHeaders(
+            'accept-encoding', ['foo;q=1.0, bar;q=0.5, baz'])
         self.assertFalse(self.wrapped.canCompress(self.request))
 
-        self.request.received_headers['accept-encoding'] = 'gzip'
+        self.request.requestHeaders.setRawHeaders('accept-encoding', ['gzip'])
         self.assertTrue(self.wrapped.canCompress(self.request))
 
-        self.request.received_headers['accept-encoding'] = 'gzip;q=0.5'
+        self.request.requestHeaders.setRawHeaders(
+            'accept-encoding', ['gzip;q=0.5'])
         self.assertTrue(self.wrapped.canCompress(self.request))
 
-        self.request.received_headers['accept-encoding'] = 'gzip;q=0'
+        self.request.requestHeaders.setRawHeaders(
+            'accept-encoding', ['gzip;q=0'])
         self.assertFalse(self.wrapped.canCompress(self.request))

--- a/nevow/test/test_static.py
+++ b/nevow/test/test_static.py
@@ -28,110 +28,120 @@ class Range(unittest.TestCase):
         self.request = testutil.FakeRequest()
 
     def testBodyLength(self):
-        self.request.received_headers['range'] = 'bytes=0-1999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-1999'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(len(r.v), 2000))
 
     def testBodyContent(self):
-        self.request.received_headers['range'] = 'bytes=0-1999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-1999'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(r.v, 200 * '0123456789'))
 
     def testContentLength(self):
         """Content-Length of a request is correct."""
-        self.request.received_headers['range'] = 'bytes=0-1999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-1999'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '2000'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-length'), ['2000']))
 
     def testContentRange(self):
         """Content-Range of a request is correct."""
-        self.request.received_headers['range'] = 'bytes=0-1999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-1999'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
-                                        'bytes 0-1999/8000'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-range'),
+                ['bytes 0-1999/8000']))
 
     def testBodyLength_offset(self):
-        self.request.received_headers['range'] = 'bytes=3-10'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=3-10'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(len(r.v), 8))
 
     def testBodyContent_offset(self):
-        self.request.received_headers['range'] = 'bytes=3-10'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=3-10'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(r.v, '34567890'))
 
     def testContentLength_offset(self):
         """Content-Length of a request is correct."""
-        self.request.received_headers['range'] = 'bytes=3-10'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=3-10'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '8'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-length'), ['8']))
 
     def testContentRange_offset(self):
         """Content-Range of a request is correct."""
-        self.request.received_headers['range'] = 'bytes=3-10'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=3-10'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
-                                        'bytes 3-10/8000'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-range'),
+                ['bytes 3-10/8000']))
 
     def testBodyLength_end(self):
-        self.request.received_headers['range'] = 'bytes=7991-7999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-7999'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(len(r.v), 9))
 
     def testBodyContent_end(self):
-        self.request.received_headers['range'] = 'bytes=7991-7999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-7999'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(r.v, '123456789'))
 
     def testContentLength_end(self):
-        self.request.received_headers['range'] = 'bytes=7991-7999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-7999'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '9'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-length'), ['9']))
 
     def testContentRange_end(self):
-        self.request.received_headers['range'] = 'bytes=7991-7999'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-7999'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
-                                        'bytes 7991-7999/8000'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-range'),
+                ['bytes 7991-7999/8000']))
 
     def testBodyLength_openEnd(self):
-        self.request.received_headers['range'] = 'bytes=7991-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(len(r.v), 9))
 
     def testBodyContent_openEnd(self):
-        self.request.received_headers['range'] = 'bytes=7991-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(r.v, '123456789'))
 
     def testContentLength_openEnd(self):
-        self.request.received_headers['range'] = 'bytes=7991-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '9'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-length'), ['9']))
 
     def testContentRange_openEnd(self):
-        self.request.received_headers['range'] = 'bytes=7991-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=7991-'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
-                                        'bytes 7991-7999/8000'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-range'),
+                ['bytes 7991-7999/8000']))
 
     def testBodyLength_fullRange(self):
-        self.request.received_headers['range'] = 'bytes=0-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(len(r.v), 8000))
 
     def testBodyContent_fullRange(self):
-        self.request.received_headers['range'] = 'bytes=0-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-'])
         return deferredRender(self.file, self.request).addCallback(
             lambda r: self.assertEquals(r.v, 800 * '0123456789'))
 
     def testContentLength_fullRange(self):
-        self.request.received_headers['range'] = 'bytes=0-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '8000'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-length'), ['8000']))
 
     def testContentRange_fullRange(self):
-        self.request.received_headers['range'] = 'bytes=0-'
+        self.request.requestHeaders.setRawHeaders('range', ['bytes=0-'])
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
-                                        'bytes 0-7999/8000'))
+            lambda r: self.assertEquals(
+                r.responseHeaders.getRawHeaders('content-range'),
+                ['bytes 0-7999/8000']))

--- a/nevow/test/test_testutil.py
+++ b/nevow/test/test_testutil.py
@@ -76,7 +76,7 @@ class TestFakeRequest(TestCase):
         host = 'divmod.com'
         req = FakeRequest()
         req.setHeader('host', host)
-        self.assertEqual(req.headers['host'], host)
+        self.assertEqual(req.responseHeaders.getRawHeaders('host'), [host])
 
 
     def test_caseInsensitiveHeaders(self):
@@ -86,7 +86,7 @@ class TestFakeRequest(TestCase):
         """
         host = 'example.com'
         request = FakeRequest()
-        request.received_headers['host'] = host
+        request.requestHeaders.setRawHeaders('host', [host])
         self.assertEqual(request.getHeader('hOsT'), host)
 
 
@@ -138,9 +138,9 @@ class TestFakeRequest(TestCase):
         """
         req = FakeRequest()
         req.setHeader('foo', 'bar')
-        self.assertNotIn('foo', req.received_headers)
+        self.assertFalse(req.requestHeaders.hasHeader('foo'))
         self.assertEqual(req.getHeader('foo'), None)
-        req.received_headers['foo'] = 'bar'
+        req.requestHeaders.setRawHeaders('foo', ['bar'])
         self.assertEqual(req.getHeader('foo'), 'bar')
 
 

--- a/nevow/testutil.py
+++ b/nevow/testutil.py
@@ -288,6 +288,7 @@ class FakeRequest(Componentized):
         return appserver._DictHeaders(self.requestHeaders)
 
 
+
 class TestCase(TrialTestCase):
     hasBools = (sys.version_info >= (2,3))
     _assertions = 0

--- a/nevow/testutil.py
+++ b/nevow/testutil.py
@@ -3,6 +3,7 @@
 # See LICENSE for details.
 
 import os, sys, signal
+import warnings
 
 from subprocess import PIPE, Popen
 
@@ -19,6 +20,7 @@ from twisted.python.components import Componentized
 from twisted.internet import defer
 from twisted.web import http
 from twisted.protocols.basic import LineReceiver
+from twisted.web.http_headers import Headers
 
 from formless import iformless
 
@@ -110,14 +112,14 @@ class FakeRequest(Componentized):
                 self.prepath.append(self.postpath.pop(0))
         else:
             self.prepath.append('')
-        self.headers = {}
+        self.responseHeaders = Headers()
         self.args = args or {}
         self.sess = FakeSession(avatar)
         self.site = FakeSite()
-        self.received_headers = {}
+        self.requestHeaders = Headers()
         if headers:
             for k, v in headers.iteritems():
-                self.received_headers[k.lower()] = v
+                self.requestHeaders.setRawHeaders(k, [v])
         if cookies is not None:
             self.cookies = cookies
         else:
@@ -169,10 +171,10 @@ class FakeRequest(Componentized):
         self.deferred.callback('')
 
     def getHeader(self, key):
-        return self.received_headers.get(key.lower())
+        return self.requestHeaders.getRawHeaders(key, [None])[0]
 
     def setHeader(self, key, val):
-        self.headers[key.lower()] = val
+        self.responseHeaders.setRawHeaders(key, [val])
 
     def redirect(self, url):
         self.redirected_to = url
@@ -244,6 +246,46 @@ class FakeRequest(Componentized):
         Returns whether this is an HTTPS request or not.
         """
         return self.secure
+
+
+    def _warnHeaders(self, old, new):
+        """
+        Emit a warning related to use of one of the deprecated C{headers} or
+        C{received_headers} attributes.
+
+        @param old: The name of the deprecated attribute to which the warning
+            pertains.
+
+        @param new: The name of the preferred attribute which replaces the old
+            attribute.
+        """
+        warnings.warn(
+            category=DeprecationWarning,
+            message=(
+                "nevow.testutil.FakeRequest.%(old)s was deprecated in "
+                "Nevow 0.13.0: Please use nevow.testutil.FakeRequest."
+                "%(new)s instead." % dict(old=old, new=new)),
+            stacklevel=3)
+
+
+    @property
+    def headers(self):
+        """
+        Transform the L{Headers}-style C{responseHeaders} attribute into a
+        deprecated C{dict}-style C{headers} attribute.
+        """
+        self._warnHeaders("headers", "responseHeaders")
+        return appserver._DictHeaders(self.responseHeaders)
+
+
+    @property
+    def received_headers(self):
+        """
+        Transform the L{Headers}-style C{requestHeaders} attribute into a
+        deprecated C{dict}-style C{received_headers} attribute.
+        """
+        self._warnHeaders("received_headers", "requestHeaders")
+        return appserver._DictHeaders(self.requestHeaders)
 
 
 class TestCase(TrialTestCase):


### PR DESCRIPTION
Fixes #74, fixes #75.

Also add better compatibility support to FakeRequest for use of the old and new header attributes, and fix test code that tripped over the deprecation warnings.