### PR TITLE
Speed up flattening.

### DIFF
--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: nevow.test.test_athena -*-
 
-import itertools, os, re, warnings
+import itertools, os, re, warnings, StringIO
 
 from zope.interface import implements
 
@@ -1681,7 +1681,10 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         # different module from whence nevow.athena and nevow.testutil could
         # import it. -exarkun
         from nevow.testutil import FakeRequest
-        return "".join(_flat.flatten(FakeRequest(), what, False, False))
+        s = StringIO.StringIO()
+        for _ in _flat.flatten(FakeRequest(), s.write, what, False, False):
+            pass
+        return s.getvalue()
 
 
     def _structured(self):

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -293,11 +293,12 @@ def _serialize(obj, w, seen):
     elif isinstance(obj, (athena.LiveFragment, athena.LiveElement)):
         _serialize(obj._structured(), w, seen)
     elif isinstance(obj, (rend.Fragment, page.Element)):
+        def _w(s):
+            w(stringEncode(s.decode('utf-8')))
         wrapper = tags.div(xmlns="http://www.w3.org/1999/xhtml")
         w('"')
-        w(stringEncode(
-                "".join(_flat.flatten(None, wrapper[obj],
-                                      False, False)).decode('utf-8')))
+        for _ in _flat.flatten(None, _w, wrapper[obj], False, False):
+            pass
         w('"')
     else:
         transportable = IAthenaTransportable(obj, None)

--- a/nevow/test/test_newflat.py
+++ b/nevow/test/test_newflat.py
@@ -5,7 +5,7 @@
 Tests for L{nevow._flat}.
 """
 
-import sys, traceback
+import sys, traceback, StringIO
 
 from zope.interface import implements
 
@@ -25,6 +25,7 @@ from nevow.flat import flatten as oldFlatten, precompile as oldPrecompile
 from nevow.flat.ten import registerFlattener
 from nevow.testutil import FakeRequest
 from nevow.context import WovenContext
+
 
 # Use the co_filename mechanism (instead of the __file__ mechanism) because
 # it is the mechanism traceback formatting uses.  The two do not necessarily
@@ -113,16 +114,14 @@ class FlattenTests(TestCase, FlattenMixin):
     """
     Tests for L{nevow._flat.flatten}.
     """
-    def flatten(self, root, request=None):
+    def flatten(self, root, request=None, inAttribute=False, inXML=False):
         """
         Helper to get a string from L{flatten}.
         """
-        result = []
-        # This isn't something shorter because this way is nicer to look at in
-        # a debugger.
-        for part in flatten(request, root, False, False):
-            result.append(part)
-        return "".join(result)
+        s = StringIO.StringIO()
+        for _ in flatten(request, s.write, root, inAttribute, inXML):
+            pass
+        return s.getvalue()
 
 
     def test_unflattenable(self):
@@ -165,7 +164,8 @@ class FlattenTests(TestCase, FlattenMixin):
         compatibility.
         """
         self.assertStringEqual(
-            "".join(flatten(None, raw('"&<>'), True, True)), '&quot;&<>')
+            self.flatten(raw('"&<>'), inAttribute=True, inXML=True),
+            '&quot;&<>')
 
 
     def test_attributeString(self):
@@ -174,7 +174,7 @@ class FlattenTests(TestCase, FlattenMixin):
         C{True} is passed for C{inAttribute}.
         """
         self.assertStringEqual(
-            "".join(flatten(None, '"&<>', True, False)),
+            self.flatten('"&<>', inAttribute=True, inXML=False),
             "&quot;&amp;&lt;&gt;")
 
 
@@ -184,7 +184,7 @@ class FlattenTests(TestCase, FlattenMixin):
         passed for C{inXML}.
         """
         self.assertStringEqual(
-            "".join(flatten(None, '"&<>', False, True)),
+            self.flatten('"&<>', inAttribute=False, inXML=True),
             '"&amp;&lt;&gt;')
 
 


### PR DESCRIPTION
This optimization passes the `write` callable down into the inner flattening loop where it can be called directly, instead of yielding a lot of small strings. This yields rather significant speedups on a benchmark I constructed: https://gist.github.com/mithrandi/54845e061217b98cdf4dd7700277f6a2