### PR TITLE
Reset Athena transport requests to empty.

### DIFF
--- a/nevow/js/Nevow/Athena/__init__.js
+++ b/nevow/js/Nevow/Athena/__init__.js
@@ -492,7 +492,7 @@ Nevow.Athena.ReliableMessageDelivery.methods(
         for (var i = 0; i < self.requests.length; ++i) {
             self.requests[i].abort();
         }
-        self.requests = null;
+        self.requests = [];
         self.page.connectionLost('Connection closed by remote host');
     },
 


### PR DESCRIPTION
When stopping the Athena transport reset the pending requests to an
empty array instead of `null`, to avoid breaking all the other code that
expects to be able to iterate it.

Fixes #84.