### PR TITLE
Implement a client-side request timeout

### DIFF
--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1017,6 +1017,17 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
     useActiveChannels = True
 
+    # This is the amount of time that each 'transport' request will remain open
+    # to the server.  Although the underlying transport, i.e. the conceptual
+    # connection established by the sequence of requests, remains alive, it is
+    # necessary to periodically cancel requests to avoid browser and proxy
+    # bugs.
+    TRANSPORT_IDLE_TIMEOUT = 30
+
+    # The client-side transport timeout; this is set higher than the server
+    # idle timeout to allow for round-trip delays.
+    TRANSPORT_CLIENT_IDLE_TIMEOUT = TRANSPORT_IDLE_TIMEOUT + 10
+
     # This is the number of seconds that is acceptable for a LivePage to be
     # considered 'connected' without any transports still active.  In other
     # words, if the browser cannot make requests for more than this timeout
@@ -1024,14 +1035,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
     # proxies) then deferreds returned from notifyOnDisconnect() will be
     # errbacked with ConnectionLost, and the LivePage will be removed from the
     # factory's cache, and then likely garbage collected.
-    TRANSPORTLESS_DISCONNECT_TIMEOUT = 30
-
-    # This is the amount of time that each 'transport' request will remain open
-    # to the server.  Although the underlying transport, i.e. the conceptual
-    # connection established by the sequence of requests, remains alive, it is
-    # necessary to periodically cancel requests to avoid browser and proxy
-    # bugs.
-    TRANSPORT_IDLE_TIMEOUT = 300
+    TRANSPORTLESS_DISCONNECT_TIMEOUT = TRANSPORT_CLIENT_IDLE_TIMEOUT * 2 + 10
 
     page = property(lambda self: self)
 
@@ -1394,7 +1398,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         """
         return [
             ("Divmod.bootstrap",
-             [flat.flatten(self.transportRoot, ctx).decode("ascii")]),
+             [flat.flatten(self.transportRoot, ctx).decode("ascii"),
+              self.TRANSPORT_CLIENT_IDLE_TIMEOUT]),
             ("Nevow.Athena.bootstrap",
              [self.jsClass, self.clientID.decode('ascii')])]
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1035,6 +1035,11 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
     # proxies) then deferreds returned from notifyOnDisconnect() will be
     # errbacked with ConnectionLost, and the LivePage will be removed from the
     # factory's cache, and then likely garbage collected.
+    #
+    # This timeout races against TRANSPORT_CLIENT_IDLE_TIMEOUT in cases where
+    # the server has sent a response, but the client has not received it; we
+    # set the value to 2 client timeouts plus some padding to give the client
+    # two chances to retry.
     TRANSPORTLESS_DISCONNECT_TIMEOUT = TRANSPORT_CLIENT_IDLE_TIMEOUT * 2 + 10
 
     page = property(lambda self: self)

--- a/nevow/js/Divmod/Runtime/__init__.js
+++ b/nevow/js/Divmod/Runtime/__init__.js
@@ -595,6 +595,9 @@ Divmod.Runtime.Platform.namedMethods({
         // Build request with appropriate headers.
         var req = self.makeHTTPRequest();
         req.open(action, url, !synchronous);
+        if (!synchronous) {
+            req.timeout = Divmod._transportTimeout * 1000;
+        }
         for (var i = 0; i < headers.length; ++i) {
             req.setRequestHeader(headers[i][0], headers[i][1]);
         }

--- a/nevow/js/Divmod/Test/TestRuntime.js
+++ b/nevow/js/Divmod/Test/TestRuntime.js
@@ -120,6 +120,7 @@ Divmod.Test.TestRuntime.NetworkTests.methods(
      * string if the request succeeds.
      */
     function test_getPage(self) {
+        Divmod._transportTimeout = 42;
         var gp = self.platform.getPage('/hello/world');
         var realResult = null;
         self.assertIdentical(gp.length, 2);
@@ -127,6 +128,7 @@ Divmod.Test.TestRuntime.NetworkTests.methods(
         self.assertArraysEqual(self.httpRequest.opened,
                                ['GET', '/hello/world', true]);
         self.assertArraysEqual(self.httpRequest.sent, ['']);
+        self.assertIdentical(self.httpRequest.timeout, 42 * 1000);
 
         self.assert(gp[1] instanceof Divmod.Defer.Deferred);
         gp[1].addCallback(function (result) {

--- a/nevow/js/Divmod/__init__.js
+++ b/nevow/js/Divmod/__init__.js
@@ -9,9 +9,13 @@ Divmod.debugging = false;
  *
  * @param transportRoot: a string, the URL where the root of the server-side
  * Athena transport hierarchy for the current page is located.
+ *
+ * @param transportTimeout: The number of seconds timeout to allow on transport
+ * requests.
  */
-Divmod.bootstrap = function (transportRoot) {
+Divmod.bootstrap = function (transportRoot, transportTimeout) {
     this._location = transportRoot;
+    this._transportTimeout = transportTimeout;
 };
 
 

--- a/nevow/js/Nevow/Athena/__init__.js
+++ b/nevow/js/Nevow/Athena/__init__.js
@@ -460,6 +460,7 @@ Nevow.Athena.PageWidget.methods(
     });
 
 Nevow.Athena.ReliableMessageDelivery = Divmod.Class.subclass('Nevow.Athena.ReliableMessageDelivery');
+Nevow.Athena.ReliableMessageDelivery.MAX_FAILURES = 5;
 
 /**
  * A L{ReliableMessageDelivery} is a queue through which messages may be
@@ -486,6 +487,7 @@ Nevow.Athena.ReliableMessageDelivery.methods(
         self.outputFactory = outputFactory;
         self.requests = [];
         self.page = page;
+        self.maxFailures = Nevow.Athena.ReliableMessageDelivery.MAX_FAILURES;
         if (page === undefined) {
             throw new Error("Must supply a page.");
         }
@@ -602,7 +604,7 @@ Nevow.Athena.ReliableMessageDelivery.methods(
                     break;
                 }
             }
-            if (self.failureCount < 3) {
+            if (self.failureCount < self.maxFailures) {
                 if (!theRequest.aborted) {
                     self.flushMessages();
                 }

--- a/nevow/jsutil.py
+++ b/nevow/jsutil.py
@@ -63,7 +63,7 @@ def findJavascriptInterpreter():
     Return a string path to a JavaScript interpreter if one can be found in
     the executable path. If not, return None.
     """
-    for script in ['smjs', 'js']:
+    for script in ['smjs', 'js24', 'js']:
         _jsInterps = which(script)
         if _jsInterps:
             return _jsInterps[0]

--- a/nevow/test/test_athena.py
+++ b/nevow/test/test_athena.py
@@ -1631,7 +1631,7 @@ class LivePageTests(unittest.TestCase, CSSModuleTestMixin):
               # Nevow's URL quoting rules are weird, but this is the URL
               # flattener's fault, not mine.  Adjust to taste if that changes
               # (it won't) -glyph
-              [u"http://localhost/'%22"]),
+              [u"http://localhost/'%22", 40]),
              ("Nevow.Athena.bootstrap",
               [u'Nevow.Athena.PageWidget', u'asdf'])])
 


### PR DESCRIPTION
Closes #98.

I also tweaked the timeout values in general, and raised the max failures
count; hopefully this should all increase robustness somewhat. The functioning
of the timeout behaviour was tested by hand with Chrome and IE 11, but I think
it should work in IE 8 and up. Older browsers just won't get a timeout, I
think, which is unfortunate, but they're no worse off than before.