### PR TITLE
Working python3 version

### DIFF
--- a/benchmarks/json_string_tokenizer.py
+++ b/benchmarks/json_string_tokenizer.py
@@ -22,7 +22,7 @@ class StringTokenizer(Options):
         self['scale'] = int(self['scale'])
 
 
-BASE = u'Hello, world.  "Quotes".'
+BASE = 'Hello, world.  "Quotes".'
 def benchmark(iterations, scale):
     """
     Deserialize a string C{iterations} times.  Make the string longer based
@@ -32,10 +32,10 @@ def benchmark(iterations, scale):
     """
     s = serialize(BASE * scale)
     before = time()
-    for i in xrange(iterations):
+    for i in range(iterations):
         parse(s)
     after = time()
-    print (after - before) / iterations, 'per call'
+    print((after - before) / iterations, 'per call')
 
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,8 +52,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Nevow'
-copyright = u'2014, Twisted developers'
+project = 'Nevow'
+copyright = '2014, Twisted developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -205,8 +205,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'Nevow.tex', u'Nevow Documentation',
-   u'Twisted developers', 'manual'),
+  ('index', 'Nevow.tex', 'Nevow Documentation',
+   'Twisted developers', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -235,8 +235,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'nevow', u'Nevow Documentation',
-     [u'Twisted developers'], 1)
+    ('index', 'nevow', 'Nevow Documentation',
+     ['Twisted developers'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -249,8 +249,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Nevow', u'Nevow Documentation',
-   u'Twisted developers', 'Nevow', 'One line description of project.',
+  ('index', 'Nevow', 'Nevow Documentation',
+   'Twisted developers', 'Nevow', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/doc/howto/chattutorial/part00/listings/echothing/echobox.py
+++ b/doc/howto/chattutorial/part00/listings/echothing/echobox.py
@@ -5,7 +5,7 @@ from nevow.loaders import xmlfile
 class EchoElement(LiveElement):
 
     docFactory = xmlfile(sibpath(__file__, 'template.html'))
-    jsClass = u'EchoThing.EchoWidget'
+    jsClass = 'EchoThing.EchoWidget'
 
     def say(self, message):
         self.callRemote('addText', message)

--- a/doc/howto/chattutorial/part01/listings/chatthing/chatterbox.py
+++ b/doc/howto/chattutorial/part01/listings/chatthing/chatterbox.py
@@ -26,7 +26,7 @@ chat = ChatRoom().makeChatter
 class ChatterElement(LiveElement):
 
     docFactory = xmlfile(sibpath(__file__, 'template.html'))
-    jsClass = u'ChatThing.ChatterWidget'
+    jsClass = 'ChatThing.ChatterWidget'
 
     def __init__(self, room):
         self.room = room

--- a/examples/advanced_manualform/advanced_manualform.py
+++ b/examples/advanced_manualform/advanced_manualform.py
@@ -61,7 +61,7 @@ class ManualFormMixin(rend.Page):
             magicCookie = str(now())
             refpath = refpath.replace('_nevow_carryover_', magicCookie)
             _CARRYOVER[magicCookie] = C = tpc.Componentized()
-            for k, v in aspects.iteritems():
+            for k, v in aspects.items():
                 C.setComponent(k, v)
             request.redirect(str(refpath))
             from nevow import static
@@ -99,8 +99,8 @@ class Page(ManualFormMixin, rend.Page):
     def form_post_btn1(self, what=None):
         # 'what' is a keyword argument, and must be the same name that you
         # give to the widget.
-        print "btn1:", what
+        print("btn1:", what)
     
     def form_post_btn2(self, what=None):
         # see above for 'what'.
-        print "btn2:", what
+        print("btn2:", what)

--- a/examples/athenademo/benchmark.py
+++ b/examples/athenademo/benchmark.py
@@ -1,5 +1,5 @@
 
-from __future__ import division
+
 
 from twisted.python import filepath
 
@@ -31,7 +31,7 @@ class Benchmark(athena.LivePage):
             yield top
 
 class InitializationBenchmark(athena.LiveFragment):
-    jsClass = u'Nevow.Benchmarks.InitializationBenchmark'
+    jsClass = 'Nevow.Benchmarks.InitializationBenchmark'
 
     docFactory = loaders.stan(
         tags.div(render=tags.directive('liveFragment'))[

--- a/examples/athenademo/calculator.html
+++ b/examples/athenademo/calculator.html
@@ -23,6 +23,10 @@
 
         <table class="calculator" id="calculator" n:pattern="CalculatorPattern" n:render="liveElement"
                 xmlns:athena="http://divmod.org/ns/athena/0.7">
+                <div n:render="subcalc"> test </div>
+                
+                <div class="subcalc" id="subcalc" n:pattern="subcalcPattern" n:render="liveElement" xmlns:athena="http://divmod.org/ns/athena/0.7"><athena:handler event="onclick" handler="subclicked" />hello world</div>
+                
             <tr>
                 <td colspan="4" class="output" id="output">0</td>
             </tr>

--- a/examples/athenademo/calculator.js
+++ b/examples/athenademo/calculator.js
@@ -6,6 +6,9 @@ CalculatorDemo.Calculator.methods(
     /**
      * Handle click events on any of the calculator buttons.
      */
+     function subclicked(self, node){
+         alert(10);
+     },
     function buttonClicked(self, node) {
         var symbol = node.value;
         d = self.callRemote("buttonClicked", symbol);

--- a/examples/athenademo/calculator.py
+++ b/examples/athenademo/calculator.py
@@ -28,8 +28,8 @@ class Calculator(object):
         entered into the calculator.  For example, if the buttons '3', '5', and
         '+' have been pressed (in that order), C{expression} will be C{'35+'}.
     """
-    defaultExpression = u'0'
-    errorExpression = u'E'
+    defaultExpression = '0'
+    errorExpression = 'E'
 
     def __init__(self):
         self.expression = self.defaultExpression
@@ -57,7 +57,7 @@ class Calculator(object):
         # Evaluate the expression
         if symbol == '=':
             try:
-                self.expression = unicode(eval(self.expression))
+                self.expression = str(eval(self.expression))
             except ZeroDivisionError:
                 self.expression = self.errorExpression
             return self.expression
@@ -86,7 +86,7 @@ class CalculatorElement(LiveElement):
     """
     docFactory = xmlfile(sibling('calculator.html').path, 'CalculatorPattern')
 
-    jsClass = u"CalculatorDemo.Calculator"
+    jsClass = "CalculatorDemo.Calculator"
 
     validSymbols = '0123456789/*-=+.C'
 
@@ -123,7 +123,7 @@ class CalculatorParentPage(LivePage):
         # Update the mapping of known JavaScript modules so that the
         # client-side code for this example can be found and served to the
         # browser.
-        self.jsModules.mapping[u'CalculatorDemo'] = sibling(
+        self.jsModules.mapping['CalculatorDemo'] = sibling(
             'calculator.js').path
 
 

--- a/examples/athenademo/calculator.py
+++ b/examples/athenademo/calculator.py
@@ -14,6 +14,7 @@ from twisted.internet import reactor
 from nevow.athena import LivePage, LiveElement, expose
 from nevow.loaders import xmlfile
 from nevow.appserver import NevowSite
+from nevow.page import renderer
 
 # Handy helper for finding external resources nearby.
 sibling = FilePath(__file__).sibling
@@ -69,6 +70,13 @@ class Calculator(object):
         return self.expression
 
 
+class SubCal(LiveElement):
+    docFactory = xmlfile(sibling('calculator.html').path, 'subcalcPattern')
+
+    jsClass = u"CalculatorDemo.Calculator"
+    def __init__(self, par):
+        self.setFragmentParent(par)
+        
 
 class CalculatorElement(LiveElement):
     """
@@ -86,7 +94,7 @@ class CalculatorElement(LiveElement):
     """
     docFactory = xmlfile(sibling('calculator.html').path, 'CalculatorPattern')
 
-    jsClass = "CalculatorDemo.Calculator"
+    jsClass = u"CalculatorDemo.Calculator"
 
     validSymbols = '0123456789/*-=+.C'
 
@@ -94,7 +102,10 @@ class CalculatorElement(LiveElement):
         LiveElement.__init__(self)
         self.calc = calc
 
-
+    @renderer
+    def subcalc(self, *args):
+        return SubCal(self)
+    
     def buttonClicked(self, symbol):
         """
         Accept a symbol from the browser, perform input validation on it,
@@ -135,6 +146,7 @@ class CalculatorParentPage(LivePage):
         c.setFragmentParent(self)
         return c
 
+    
 
 
 def main():

--- a/examples/athenademo/calculator.py
+++ b/examples/athenademo/calculator.py
@@ -138,7 +138,7 @@ class CalculatorParentPage(LivePage):
 
 
 def main():
-   # log.startLogging(sys.stdout)
+    log.startLogging(sys.stdout)
     site = NevowSite(CalculatorParentPage(calc=Calculator()))
     reactor.listenTCP(8081, site)
     reactor.run()

--- a/examples/athenademo/calculator.py
+++ b/examples/athenademo/calculator.py
@@ -138,7 +138,7 @@ class CalculatorParentPage(LivePage):
 
 
 def main():
-    log.startLogging(sys.stdout)
+   # log.startLogging(sys.stdout)
     site = NevowSite(CalculatorParentPage(calc=Calculator()))
     reactor.listenTCP(8080, site)
     reactor.run()

--- a/examples/athenademo/calculator.py
+++ b/examples/athenademo/calculator.py
@@ -140,7 +140,7 @@ class CalculatorParentPage(LivePage):
 def main():
    # log.startLogging(sys.stdout)
     site = NevowSite(CalculatorParentPage(calc=Calculator()))
-    reactor.listenTCP(8080, site)
+    reactor.listenTCP(8081, site)
     reactor.run()
 
 

--- a/examples/athenademo/typeahead.py
+++ b/examples/athenademo/typeahead.py
@@ -3,10 +3,10 @@ from nevow import tags as T, rend, loaders, athena, url
 from formless import annotate, webform
 from twisted.python import util
 
-animals = {u'elf' : u'Pointy ears.  Bad attitude regarding trees.',
-           u'chipmunk': u'Cute.  Fuzzy.  Sings horribly.',
-           u'chupacabra': u'It sucks goats.',
-           u'ninja': u'Stealthy and invisible, and technically an animal.',
+animals = {'elf' : 'Pointy ears.  Bad attitude regarding trees.',
+           'chipmunk': 'Cute.  Fuzzy.  Sings horribly.',
+           'chupacabra': 'It sucks goats.',
+           'ninja': 'Stealthy and invisible, and technically an animal.',
            }
 
 
@@ -26,8 +26,8 @@ class TypeAheadFieldFragment(athena.LiveFragment):
                 ])
 
     def loadDescription(self, typed):
-        if typed == u'':
-            return None, u'--'
+        if typed == '':
+            return None, '--'
         matches = []
         for key in animals:
             if key.startswith(typed):
@@ -35,9 +35,9 @@ class TypeAheadFieldFragment(athena.LiveFragment):
         if len(matches) == 1:
             return matches[0], animals[matches[0]]
         elif len(matches) > 1:
-            return None, u"(Multiple found)"
+            return None, "(Multiple found)"
         else:
-            return None, u'--'
+            return None, '--'
     athena.expose(loadDescription)
 
 class DataEntry(rend.Page):
@@ -75,7 +75,7 @@ class DataEntry(rend.Page):
         return url.here
 
     def data_animals(self, ctx, data):
-        return animals.keys()
+        return list(animals.keys())
 
     def child_typeahead(self, ctx):
         return TypeAheadPage(None, None)

--- a/examples/athenademo/widgets.py
+++ b/examples/athenademo/widgets.py
@@ -7,7 +7,7 @@ from twisted.python import log, util
 from nevow import athena, loaders, static
 
 class Clock(athena.LiveFragment):
-    jsClass = u"WidgetDemo.Clock"
+    jsClass = "WidgetDemo.Clock"
 
     docFactory = loaders.xmlstr('''\
 <div xmlns:nevow="http://nevow.com/ns/nevow/0.1"
@@ -49,7 +49,7 @@ class Clock(athena.LiveFragment):
             self.running = False
 
     def updateTime(self):
-        self.callRemote('setTime', unicode(time.ctime(), 'ascii')).addErrback(self._oops)
+        self.callRemote('setTime', str(time.ctime(), 'ascii')).addErrback(self._oops)
 
 class WidgetPage(athena.LivePage):
     docFactory = loaders.xmlstr("""\
@@ -73,7 +73,7 @@ class WidgetPage(athena.LivePage):
 
     def __init__(self, *a, **kw):
         super(WidgetPage, self).__init__(*a, **kw)
-        self.jsModules.mapping[u'WidgetDemo'] = util.sibpath(__file__, 'widgets.js')
+        self.jsModules.mapping['WidgetDemo'] = util.sibpath(__file__, 'widgets.js')
 
     def childFactory(self, ctx, name):
         ch = super(WidgetPage, self).childFactory(ctx, name)

--- a/examples/blogengine/axiomstore.py
+++ b/examples/blogengine/axiomstore.py
@@ -38,10 +38,10 @@ class Blog(item.Item, item.InstallableMixin):
         self.posts = sequence.List(store=self.store)
         post = Post(store=self.store,
                     id=self.getNextId(),
-                    author=u'mike',
-                    title=u'FIRST POST!!!!',
-                    category=u'Test',
-                    content=u'I guess it worked.')
+                    author='mike',
+                    title='FIRST POST!!!!',
+                    category='Test',
+                    content='I guess it worked.')
         self.addNewPost(post)
 
     def installOn(self, other):

--- a/examples/blogengine/axiomstore.py
+++ b/examples/blogengine/axiomstore.py
@@ -1,5 +1,5 @@
 from iblogengine import IBlog
-from zope.interface import implements
+from zope.interface import implementer
 from axiom import item, store, attributes, sequence
 from epsilon.extime import Time
 
@@ -24,8 +24,8 @@ class Post(item.Item):
     def setModified(self):
         self.modified = Time()
 
+@implementer(IBlog)
 class Blog(item.Item, item.InstallableMixin):
-    implements(IBlog)
 
     typeName = "BlogengineBlog"
     schemaVersion = 1

--- a/examples/blogengine/email_client.py
+++ b/examples/blogengine/email_client.py
@@ -1,8 +1,8 @@
 import sys, smtplib
 
-fromaddr = raw_input("From: ")
-toaddrs  = raw_input("To: ").split(',')
-print "Enter message, end with ^D:"
+fromaddr = input("From: ")
+toaddrs  = input("To: ").split(',')
+print("Enter message, end with ^D:")
 msg = ''
 while 1:
     line = sys.stdin.readline()

--- a/examples/blogengine/frontend.py
+++ b/examples/blogengine/frontend.py
@@ -132,10 +132,10 @@ class NewEntry(BaseUI):
     def insert(self, ctx, id, title, author, category, content):
         newPost = Post(store=IStore(ctx),
                        id=int(id),
-                       author=unicode(author),
-                       title=unicode(title),
-                       category=unicode(category),
-                       content=unicode(content))
+                       author=str(author),
+                       title=str(title),
+                       category=str(category),
+                       content=str(content))
         IBlog(IStore(ctx)).addNewPost(newPost)
         inevow.IRequest(ctx).setComponent(iformless.IRedirectAfterPost, '/thx')
 
@@ -165,10 +165,10 @@ class Entry(UI):
         return webform.renderForms()
 
     def insert(self, ctx, id, title, author, category, content):
-        self.original.author = unicode(author)
-        self.original.title = unicode(title)
-        self.original.category = unicode(category)
-        self.original.content = unicode(content)
+        self.original.author = str(author)
+        self.original.title = str(title)
+        self.original.category = str(category)
+        self.original.content = str(content)
         inevow.IRequest(ctx).setComponent(iformless.IRedirectAfterPost, '/thx')
 
 #####################################
@@ -213,10 +213,10 @@ class BlogRPC(xmlrpc.XMLRPC):
         newid = IBlog(self.store).getNextId()
         newPost = Post(store=self.store,
                        id=newid,
-                       author=unicode(author),
-                       title=unicode(title),
-                       category=unicode(category),
-                       content=unicode(content))
+                       author=str(author),
+                       title=str(title),
+                       category=str(category),
+                       content=str(content))
         IBlog(self.store).addNewPost(newPost)
         return 'Successfully added post number %s' % newid
     xmlrpc_publish = transacted(xmlrpc_publish)

--- a/examples/blogengine/frontend.py
+++ b/examples/blogengine/frontend.py
@@ -176,7 +176,7 @@ class Atom(BaseUI):
     docFactory = loaders.xmlfile('atom.xml')
     
     def beforeRender(self, ctx):
-        inevow.IRequest(ctx).setHeader("Content-Type", "application/application+xml; charset=UTF-8")
+        inevow.IRequest(ctx).setHeader(b"Content-Type", "application/application+xml; charset=UTF-8")
     
     def data_getFirstPost(self, ctx, data):
         for post in IBlog(IStore(ctx)).getPosts(1):

--- a/examples/blogengine/frontend.py
+++ b/examples/blogengine/frontend.py
@@ -1,5 +1,5 @@
 from time import time as now
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.web import xmlrpc
 from twisted.python.components import registerAdapter
@@ -109,8 +109,8 @@ class UI(BaseUI):
         return Thx()
 
 ##################################
+@implementer(IInsert)
 class NewEntry(BaseUI):
-    implements(IInsert)
                 
     docFactory = loaders.stan(
         t.html[
@@ -150,8 +150,8 @@ class Thx(rend.Page):
             ])
 
 ####################################
+@implementer(IInsert)
 class Entry(UI):
-    implements(IInsert)
     def data_getEntries(self, ctx, data):
         return [data]
 

--- a/examples/blogengine/smtpserver.py
+++ b/examples/blogengine/smtpserver.py
@@ -92,15 +92,15 @@ class BlogMessage:
         post['content'] = '\n'.join(ctnt_buff)
         
         for header in 'content author category title'.split():
-            if not post.has_key(header):
+            if header not in post:
                 self.lines = []
                 return defer.fail(None) 
-        if post.has_key('id'):
+        if 'id' in post:
             oldpost = IBlog(self.store).getOne(int(post['id']))
-            oldpost.author = unicode(post['author'])
-            oldpost.title = unicode(post['title'])
-            oldpost.category = unicode(post['category'])
-            oldpost.content = unicode(post['content'])
+            oldpost.author = str(post['author'])
+            oldpost.title = str(post['title'])
+            oldpost.category = str(post['category'])
+            oldpost.content = str(post['content'])
             oldpost.setModified()
             action = 'modified'
             id = post['id']
@@ -108,10 +108,10 @@ class BlogMessage:
             newid = IBlog(self.store).getNextId()
             newPost = Post(store=self.store,
                            id=newid,
-                           author=unicode(post['author']),
-                           title=unicode(post['title']),
-                           category=unicode(post['category']),
-                           content=unicode(post['content']))
+                           author=str(post['author']),
+                           title=str(post['title']),
+                           category=str(post['category']),
+                           content=str(post['content']))
             IBlog(self.store).addNewPost(newPost)
             action = 'added'
             id = newid
@@ -125,7 +125,7 @@ Post number %s successfully %s
     eomReceived = transacted(eomReceived)
     
     def toLog(self, what):
-        print what
+        print(what)
         
     def sendNotify(self, to_addr, msg):
         d = smtp.sendmail(SMTP_HOST, FROM, to_addr, msg)

--- a/examples/blogengine/smtpserver.py
+++ b/examples/blogengine/smtpserver.py
@@ -5,7 +5,7 @@
 """
 A toy email server.
 """
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import defer
 from twisted.mail import smtp
@@ -31,8 +31,8 @@ Title: TITLE
 Content: CONTENT
 """
 
+@implementer(smtp.IMessageDelivery)
 class BlogMessageDelivery:
-    implements(smtp.IMessageDelivery)
     def __init__(self, store):
         self.store = store
     
@@ -49,8 +49,8 @@ class BlogMessageDelivery:
             return lambda: BlogMessage(self.store)
         raise smtp.SMTPBadRcpt(user)
 
+@implementer(smtp.IMessage)
 class BlogMessage:
-    implements(smtp.IMessage)
     
     def __init__(self, store):
         self.lines = []

--- a/examples/canvas/canvas.py
+++ b/examples/canvas/canvas.py
@@ -3,6 +3,7 @@ import os, string, random
 from twisted.internet import task
 
 from nevow import canvas, rend
+import imp
 
 
 DEBUG = False
@@ -84,7 +85,7 @@ class CanvasDemo(canvas.Canvas):
         """Demo of drawing with a CanvasSocket object.
         """
         ## Create a bunch of groups
-        for x in xrange(random.randint(5, 15)):
+        for x in range(random.randint(5, 15)):
             newGroup = canvas.group()
             if random.choice([True, False]):
                 Alphaerizer(newGroup)
@@ -164,7 +165,7 @@ class Reloader(rend.Page):
     canvas = None
     def locateChild(self, ctx, segs):
         if segs == ('',):
-            reload(__import__(__name__))
+            imp.reload(__import__(__name__))
             self.canvas = CanvasDemo(words)
             self.canvas.addSlash = True
             return self.canvas, segs

--- a/examples/children/childrenhtml.py
+++ b/examples/children/childrenhtml.py
@@ -22,7 +22,7 @@ class ChildPage(rend.Page):
         self.name = name
 
     def child_childOfChild(self, context):
-        print "istanzaaa"
+        print("istanzaaa")
         return ChildOfChildPage(self.name)
 
     def render_name(self, context, data):

--- a/examples/customform/customform.py
+++ b/examples/customform/customform.py
@@ -136,7 +136,7 @@ class Root(rend.Page):
         return webform.renderForms()[FORM_LAYOUT]
     
     def doSomething(self, ctx, **kwargs):
-        print '***** doSomething called with:', kwargs
+        print('***** doSomething called with:', kwargs)
     
     docFactory = loaders.stan(
         T.html[

--- a/examples/customform/customform.py
+++ b/examples/customform/customform.py
@@ -4,7 +4,7 @@
 #from twisted.application import internet, service
 #from twisted.web import static
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import rend
 from nevow import url
@@ -121,10 +121,10 @@ class ISomething(annotate.TypedInterface):
     doSomething = annotate.autocallable(doSomething)
     
 
+@implementer(ISomething)
 class Root(rend.Page):
     """Render a custom and normal form for an ISomething.
     """
-    implements(ISomething)
     addSlash = True
     
     child_webform_css = webform.defaultCSS

--- a/examples/db/db.py
+++ b/examples/db/db.py
@@ -1,5 +1,5 @@
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import inevow
 from nevow import loaders
@@ -46,8 +46,8 @@ class IAddItem(annotate.TypedInterface):
     addItem = annotate.autocallable(addItem)
 
 
+@implementer(IAddItem)
 class DBBrowser(rend.Page):
-    implements(IAddItem)
     addSlash = True
 
     def addItem(self, newSubject):
@@ -94,8 +94,8 @@ class IItemWithSubject(annotate.TypedInterface):
     setSubject = annotate.autocallable(setSubject)
 
 
+@implementer(IItemWithSubject)
 class DBItem(rend.Page):
-    implements(IItemWithSubject)
     addSlash=True
 
     def setSubject(self, newSubject):

--- a/examples/db/db.py
+++ b/examples/db/db.py
@@ -28,7 +28,7 @@ def doQuery(q, *args):
         for dbid, subj in whole:
             if dbid == theId:
                 return [(dbid, subj)]
-        raise KeyError, theId
+        raise KeyError(theId)
     elif q.startswith(setsql):
         newsubj, theId = args
         for index, (dbid, subj) in enumerate(whole):

--- a/examples/examples.tac
+++ b/examples/examples.tac
@@ -1,18 +1,15 @@
 try:
     import zope.interface
 except ImportError:
-    print """ Please install ZopeInterface product from
+    print(""" Please install ZopeInterface product from
     http://www.zope.org/Products/ZopeInterface/
-to run Nevow """
+to run Nevow """)
     import sys
     sys.exit(1)
 
 
 from twisted.python import components
 import warnings
-warnings.filterwarnings(
-    'ignore',
-    category=components.ComponentsDeprecationWarning)
 
 from twisted.application import service, strports
 from twisted.python import util
@@ -63,7 +60,7 @@ try:
     from athenademo import typeahead
     from athenademo import widgets
     from athenademo import benchmark
-except ImportError, e:
+except ImportError as e:
     if str(e).find('No module named') != -1:
         msg = """
 Original error message:
@@ -81,7 +78,7 @@ command:
 """ % str(e)
         raise Exception(msg)
     raise e
-except AttributeError, e:
+except AttributeError as e:
     if str(e).find("'module' object has no attribute") != -1:
         msg = """
 Original error message:
@@ -99,7 +96,7 @@ class Sources(rend.Page):
 
     def render_htmlizer(self, ctx, path):
         from twisted.python import htmlizer
-        from StringIO import StringIO
+        from io import StringIO
         output = StringIO()
         try:
             htmlizer.filter(open(path), output, writer=htmlizer.SmallerHTMLWriter)

--- a/examples/examples.tac
+++ b/examples/examples.tac
@@ -41,8 +41,6 @@ try:
     from manualform import manualform
     from guarded import guarded
     from guarded import guarded2
-    from xul import xul_nevow
-    from liveanimal import liveanimal
     from most_basic import most_basic
     from http_auth import http_auth
     from logout_guard import logout_guard
@@ -53,8 +51,6 @@ try:
     from macros import macros
     from i18n import i18n, xmli18n
     from cal import cal
-    from tabbed import tabbed
-    from progress import progress
 
     from athenademo import calculator
     from athenademo import typeahead
@@ -94,15 +90,12 @@ class Sources(rend.Page):
     def __init__(self, path, _):
         rend.Page.__init__(self, path)
 
-    def render_htmlizer(self, ctx, path):
+    def render_htmlizer(self, ctx, path): 
         from twisted.python import htmlizer
         from io import StringIO
         output = StringIO()
-        try:
-            htmlizer.filter(open(path), output, writer=htmlizer.SmallerHTMLWriter)
-        except AttributeError:
-            output = StringIO("""Starting after Nevow 0.4.1 Twisted
-2.0 is a required dependency. Please install it""")
+        print(97,path)
+        htmlizer.filter(open(path), output, writer=htmlizer.SmallerHTMLWriter)
         return tags.xml(output.getvalue())
 
     docFactory = loaders.stan(
@@ -143,9 +136,7 @@ class Examples(rend.Page):
         manualform=manualform.Page(),
         guarded=guarded.createResource(),
         guarded2=guarded2.createResource(),
-        xul_nevow=xul_nevow.createResource(),
         advanced_manualform=advanced_manualform.Page(),
-        liveanimal=liveanimal.createResource(),
         http_auth=http_auth.AuthorizationRequired(),
         most_basic=most_basic.root,
         logout_guard=logout_guard.createResource(),
@@ -155,8 +146,6 @@ class Examples(rend.Page):
         i18n=i18n.createResource(),
         xmli18n=xmli18n.createResource(),
         calendar=cal.Calendar(),
-        tabbed=tabbed.TabbedPage(),
-        progress=progress.createResource(),
         fragments=fragments.Root(),
         macros=macros.Root(),
         typeahead=typeahead.DataEntry(),

--- a/examples/formbuilder/formbuilder.py
+++ b/examples/formbuilder/formbuilder.py
@@ -1,6 +1,6 @@
 ## formbuilder
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import rend
 from nevow import loaders
@@ -56,8 +56,8 @@ class IFormBuilder(annotate.TypedInterface):
     clearForm = annotate.autocallable(clearForm)
         
 
+@implementer(IFormBuilder)
 class FormBuilder(rend.Page):
-    implements(IFormBuilder)
     addSlash = True
 
     def __init__(self):

--- a/examples/formbuilder/formbuilder.py
+++ b/examples/formbuilder/formbuilder.py
@@ -28,7 +28,7 @@ class BuilderCore(configurable.Configurable):
             annotate.Method(arguments=self.formElements))
 
     def action(self, **kw):
-        print "ACTION!", kw
+        print("ACTION!", kw)
 
     def addElement(self, name, type):
         self.formElements.append(

--- a/examples/formpost/formpost.py
+++ b/examples/formpost/formpost.py
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import loaders
 from nevow import rend
@@ -14,8 +14,8 @@ class IMyForm(annotate.TypedInterface):
     foo = annotate.Integer()
 
 
+@implementer(IMyForm)
 class FormPage(rend.Page):
-    implements(IMyForm)
 
     addSlash = True
 

--- a/examples/formpost/formpost2.py
+++ b/examples/formpost/formpost2.py
@@ -18,7 +18,7 @@ from twisted.internet import defer
 
 # If you still want to use an attribute or method of some other object, you should use a function as shown below,
 # but look up IResource(ctx) or IConfigurable(ctx), whichever is more appropriate.
-newChoicesWay = annotate.Choice(lambda c, d: range(30))
+newChoicesWay = annotate.Choice(lambda c, d: list(range(30)))
 deferChoicesWay = annotate.Choice(lambda c, d: defer.succeed(['abcd', 'efgh', 'ijkl']))
 radioChoices = annotate.Radio(["Old", "Tyme", "Radio"])
 

--- a/examples/formpost/formpost2.py
+++ b/examples/formpost/formpost2.py
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import loaders
 from nevow import rend
@@ -40,8 +40,8 @@ class IMyForm(annotate.TypedInterface):
     bar = annotate.autocallable(bar)
 
 
+@implementer(IMyForm)
 class Implementation(object):
-    implements(IMyForm)
 
     foo = 5
 

--- a/examples/guarded/guarded.py
+++ b/examples/guarded/guarded.py
@@ -1,5 +1,5 @@
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.cred import portal, checkers, credentials
 
@@ -60,11 +60,11 @@ def noLogout():
     return None
 
 
+@implementer(portal.IRealm)
 class MyRealm:
     """A simple implementor of cred's IRealm.
        For web, this gives us the LoggedIn page.
     """
-    implements(portal.IRealm)
 
     def requestAvatar(self, avatarId, mind, *interfaces):
         for iface in interfaces:

--- a/examples/guarded/guarded.py
+++ b/examples/guarded/guarded.py
@@ -52,7 +52,7 @@ class LoggedIn(rend.Page):
     def logout(self):
         ## self.original is the page's main data -- the object that was passed in to the constructor, and
         ## the object that is initially passed as the 'data' parameter to renderers
-        print "%s logged out!" % self.original
+        print("%s logged out!" % self.original)
 
 
 ### Authentication

--- a/examples/guarded/guarded2.py
+++ b/examples/guarded/guarded2.py
@@ -53,7 +53,7 @@ class MyPage(rend.Page):
         return context.tag[sess.uid]
  
     def logout(self):
-        print "Bye"
+        print("Bye")
  
 ### Authentication
 def noLogout():

--- a/examples/guarded/guarded2.py
+++ b/examples/guarded/guarded2.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.cred import portal, checkers, credentials
  
@@ -60,11 +60,11 @@ def noLogout():
     return None
  
  
+@implementer(portal.IRealm)
 class MyRealm:
     """A simple implementor of cred's IRealm.
        For web, this gives us the LoggedIn page.
     """
-    implements(portal.IRealm)
  
     def requestAvatar(self, avatarId, mind, *interfaces):
         for iface in interfaces:

--- a/examples/http_auth/http_auth.py
+++ b/examples/http_auth/http_auth.py
@@ -22,7 +22,7 @@ class AuthorizationRequired(rend.Page):
         request = inevow.IRequest(ctx)
         username, password = request.getUser(), request.getPassword()
         if (username, password) == ('', ''):
-            request.setHeader('WWW-Authenticate', 'Basic realm="Whatever"')
+            request.setHeader(b'WWW-Authenticate', 'Basic realm="Whatever"')
             request.setResponseCode(http.UNAUTHORIZED)
             return "Authentication required."
         ## They provided a username and password, so let's let them in! horray

--- a/examples/i18n/xmli18n.py
+++ b/examples/i18n/xmli18n.py
@@ -1,7 +1,7 @@
 import os
 from nevow import loaders
 from nevow.i18n import render as i18nrender
-from i18n import Common, preparePage
+from .i18n import Common, preparePage
 
 class Page(Common):
     docFactory = loaders.xmlfile(

--- a/examples/image_uploader/images.py
+++ b/examples/image_uploader/images.py
@@ -31,5 +31,5 @@ def initialize():
    s = store.Store('imagination.axiom')
    images = IImages(s, None)
    if not images:
-       Application(store=s, name=u'Imagination').installOn(s)
+       Application(store=s, name='Imagination').installOn(s)
    return s

--- a/examples/image_uploader/images.py
+++ b/examples/image_uploader/images.py
@@ -1,4 +1,4 @@
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from axiom import store, item
 from axiom.attributes import text, bytes
@@ -12,8 +12,8 @@ class Image(item.Item):
     image = bytes()
     hash = text()
 
+@implementer(IImages)
 class Application(item.Item, item.InstallableMixin):
-    implements(IImages)
 
     name = text()
 

--- a/examples/image_uploader/imagination.py
+++ b/examples/image_uploader/imagination.py
@@ -16,7 +16,7 @@ def label(length=None):
    """
 
    first = random.choice(alpha)
-   rest = [random.choice(alphaDigit) for i in xrange(length or 7)]
+   rest = [random.choice(alphaDigit) for i in range(length or 7)]
    newLabel = first + ''.join(rest)
    return newLabel
 

--- a/examples/image_uploader/imagination.py
+++ b/examples/image_uploader/imagination.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import loaders, rend, tags as t, static, url
 from formless import webform, annotate
@@ -43,9 +43,9 @@ class TransactionalPage(rend.Page):
         return self.store.transact(super(TransactionalPage, self).renderHTTP, ctx)
 
 
+@implementer(IInsert)
 class Root(TransactionalPage):
     child_webform_css = webform.defaultCSS
-    implements(IInsert)
 
     docFactory = loaders.stan(
         t.html[

--- a/examples/irenderer/irenderer.py
+++ b/examples/irenderer/irenderer.py
@@ -6,7 +6,7 @@
 
 
 import random
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 from twisted.python.components import registerAdapter, Adapter
 
 from nevow import inevow
@@ -48,10 +48,10 @@ class IFullView(Interface):
 # Define the rendering adapters that do the real work of rendering an
 # object.
 
+@implementer(inevow.IRenderer, ISummaryView)
 class PersonSummaryView(Adapter):
     """Render a summary of a Person.
     """
-    implements(inevow.IRenderer, ISummaryView)
     def rend(self, data):
         return T.div(_class="summaryView person")[
             T.a(href=['mailto:',self.original.email])[
@@ -59,10 +59,10 @@ class PersonSummaryView(Adapter):
                 ]
             ]
 
+@implementer(inevow.IRenderer, IFullView)
 class PersonFullView(Adapter):
     """Render a full view of a Person.
     """
-    implements(inevow.IRenderer, IFullView)
     def rend(self, data):
         attrs = ['firstName', 'lastName', 'email']
         return T.div(_class="fullView person")[
@@ -73,19 +73,19 @@ class PersonFullView(Adapter):
                 ]
             ]
     
+@implementer(inevow.IRenderer, ISummaryView)
 class BookmarkSummaryView(Adapter):
     """Render a summary of a Person.
     """
-    implements(inevow.IRenderer, ISummaryView)
     def rend(self, data):
         return T.div(_class="summaryView bookmark")[
             T.a(href=self.original.url)[self.original.name]
             ]
     
+@implementer(inevow.IRenderer, IFullView)
 class BookmarkFullView(Adapter):
     """Render a full view of a Bookmark.
     """
-    implements(inevow.IRenderer, IFullView)
     def rend(self, data):
         attrs = ['name', 'url']
         return T.div(_class="fullView bookmark")[

--- a/examples/irenderer/simple_irenderer.py
+++ b/examples/irenderer/simple_irenderer.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python.components import registerAdapter, Adapter
 
@@ -58,10 +58,11 @@ class Bookmark:
         self.name = name
         self.url = url
 
+
+@implementer(inevow.IRenderer)
 class PersonView(Adapter):
     """Render a full view of a Person.
     """
-    implements(inevow.IRenderer)
     def rend(self, data):
         attrs = ['firstName', 'lastName', 'nickname']
         return T.div(_class="View person")[
@@ -72,10 +73,10 @@ class PersonView(Adapter):
                 ]
             ]
 
+@implementer(inevow.IRenderer)
 class BookmarkView(Adapter):
     """Render a full view of a Bookmark.
     """
-    implements(inevow.IRenderer)
     def rend(self, data):
         attrs = ['name', 'url']
         return T.div(_class="View bookmark")[

--- a/examples/logout_guard/logout_guard.py
+++ b/examples/logout_guard/logout_guard.py
@@ -48,7 +48,7 @@ class MyRealm:
         def logout():
             # This will be a nevow.guard.GuardSession instance
             session = mind.request.getSession()
-            print 'Logging avatar', avatar_id, 'out of session', session
+            print('Logging avatar', avatar_id, 'out of session', session)
         return logout
 
 # Code for examples.tac

--- a/examples/logout_guard/logout_guard.py
+++ b/examples/logout_guard/logout_guard.py
@@ -3,7 +3,7 @@ How to access the session from guard's logout function.
 """
 
 # Some resource for our site
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import guard
 from nevow import rend
@@ -32,8 +32,8 @@ class Mind:
         self.request = request
         self.credentials = credentials
 
+@implementer(IRealm)
 class MyRealm:
-    implements(IRealm)
     
     def requestAvatar(self, avatar_id, mind, *interfaces):
         if IResource in interfaces:

--- a/examples/logout_guard/logout_guard2.py
+++ b/examples/logout_guard/logout_guard2.py
@@ -86,8 +86,8 @@ class MyRealm:
             session = mind.request.getSession()
             values = session.getComponent(IValueHistory)
             session.unsetComponent(IValueHistory)
-            print 'Logging avatar', avatar_id, 'out of session', session
-            print 'Random numbers generated were', values
+            print('Logging avatar', avatar_id, 'out of session', session)
+            print('Random numbers generated were', values)
         return logout
 
 # Code for examples.tac

--- a/examples/logout_guard/logout_guard2.py
+++ b/examples/logout_guard/logout_guard2.py
@@ -7,7 +7,7 @@ with an example of remembering values within the session.
 #
 
 import random
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from nevow import guard
 from nevow import rend
@@ -68,8 +68,8 @@ class Mind:
         self.request = request
         self.credentials = credentials
 
+@implementer(IRealm)
 class MyRealm:
-    implements(IRealm)
     
     def requestAvatar(self, avatar_id, mind, *interfaces):
         if IResource in interfaces:

--- a/examples/macros/macros.py
+++ b/examples/macros/macros.py
@@ -12,7 +12,7 @@ class Base(rend.Page):
     def render_advice(self, ctx, data):
         return ctx.tag[
             t.p["This counter has been called:"],
-            t.p(style="text-align: center")["===>",t.strong[inside_counter.next()+1],"<==="]
+            t.p(style="text-align: center")["===>",t.strong[next(inside_counter)+1],"<==="]
         ]
 
 class Root(Base):
@@ -21,7 +21,7 @@ class Root(Base):
     def macro_content(self, ctx):
         return t.invisible[
                    t.p["This macro has been called ",
-                       counter1.next()+1,
+                       next(counter1)+1,
                        " time(s)"],
                    loaders.xmlfile(util.sibpath(__file__,'root_macro.html'), ignoreDocType=True).load()
                ]
@@ -35,7 +35,7 @@ class Child(Base):
     def macro_content(self, ctx):
         return t.invisible[
                    t.p["This macro has been called ",
-                       counter2.next()+1,
+                       next(counter2)+1,
                        " time(s)"],
                    loaders.xmlfile(util.sibpath(__file__,'child_macro.html'), ignoreDocType=True).load()
             ]

--- a/examples/manualform/manualform.py
+++ b/examples/manualform/manualform.py
@@ -17,7 +17,7 @@ class Page(rend.Page):
         # Handle the form post
         if segments[0] == SUBMIT:
             # Just print out the name
-            print '*** name:', ctx.arg('name')
+            print('*** name:', ctx.arg('name'))
             # Redirect away from the POST
             return url.URL.fromContext(ctx), ()
         

--- a/examples/most_basic/most_basic.py
+++ b/examples/most_basic/most_basic.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import inevow
 
@@ -15,8 +15,8 @@ from nevow import inevow
 # tuple of (page, remaining_segments)
 # if there is no page, and you want to display a 404 page, you will need to return
 # a None, () tuple.
+@implementer(inevow.IResource)
 class Root(object):
-    implements(inevow.IResource)
 
     def locateChild(self, ctx, segments):
         # This locateChild is 'stupid' since it can only work if the tree of
@@ -42,8 +42,8 @@ class Root(object):
         <a href="./foo" id="foo">foo</a></body></html>
 """
 
+@implementer(inevow.IResource)
 class Foo(object):
-    implements(inevow.IResource)
     
     def locateChild(self, ctx, segments):
         # segments is the remaining segments returned by the root locateChild
@@ -58,8 +58,8 @@ class Foo(object):
         <a href="./foo/baz" id="baz">baz</a></body></html>
 """
 
+@implementer(inevow.IResource)
 class Baz(object):
-    implements(inevow.IResource)
     def locateChild(self, ctx, segments):
         return None, ()
     def renderHTTP(self, ctx):

--- a/examples/pastebin/pastebin/service.py
+++ b/examples/pastebin/pastebin/service.py
@@ -1,4 +1,4 @@
-import cPickle as pickle
+import pickle as pickle
 import os.path
 import time
 from zope.interface import implements

--- a/examples/pastebin/pastebin/service.py
+++ b/examples/pastebin/pastebin/service.py
@@ -1,7 +1,7 @@
 import pickle as pickle
 import os.path
 import time
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.application import service
 from twisted.python import log
@@ -19,9 +19,8 @@ class Record(object):
         self.version = 0
 
 
+@implementer(interfaces.IPasteBin)
 class FSPasteBinService(service.Service):
-
-    implements(interfaces.IPasteBin)
 
     def __init__(self, storageDir):
         self._dir = storageDir
@@ -84,9 +83,9 @@ class FSPasteBinService(service.Service):
         f = file(self._makeFilename('index'), 'wb')
         pickle.dump(d, f, pickle.HIGHEST_PROTOCOL)
 
-class Pasting(object):
-    
-    implements(pasting.IPasting)
+@implementer(pasting.IPasting)
+class Pasting(object):    
+
 
     def __init__(self, data):
         self._data = data
@@ -103,9 +102,9 @@ class Pasting(object):
         return history
                               
 
+@implementer(pasting.IVersion)
 class Version:
 
-    implements(pasting.IVersion)
 
     def __init__(self, data):
         self._data = data

--- a/examples/pastebin/pastebin/web/pages.py
+++ b/examples/pastebin/pastebin/web/pages.py
@@ -1,4 +1,4 @@
-from cStringIO import StringIO
+from io import StringIO
 import time
 from zope.interface import implements
 

--- a/examples/pastebin/pastebin/web/pages.py
+++ b/examples/pastebin/pastebin/web/pages.py
@@ -1,6 +1,6 @@
 from io import StringIO
 import time
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python import htmlizer
 from twisted.web import static
@@ -107,8 +107,8 @@ class BasePage(rend.Page):
         return tag
     
 
+@implementer(IAddPasting)
 class RootPage(BasePage):
-    implements(IAddPasting)
 
     addSlash = True
 
@@ -132,9 +132,9 @@ class RootPage(BasePage):
         request.setComponent(iformless.IRedirectAfterPost, '/'+str(oid))
         
 
+@implementer(IEditPasting)
 class Pasting(BasePage):
 
-    implements(IEditPasting)
     contentTemplateFile = 'pasting.html'
 
     def __init__(self, pastebin, pastingOid, version=-1):

--- a/examples/postit/postit.py
+++ b/examples/postit/postit.py
@@ -54,7 +54,7 @@ class Atom(Base):
     docFactory = loaders.xmlfile('atom.xml')
     
     def beforeRender(self, ctx):
-        inevow.IRequest(ctx).setHeader("Content-Type", "application/application+xml; charset=UTF-8")
+        inevow.IRequest(ctx).setHeader(b"Content-Type", "application/application+xml; charset=UTF-8")
     
     def data_getFirstPost(self, ctx, data):
         for post in IPostit(self.store).getPosts(1):

--- a/examples/postit/store.py
+++ b/examples/postit/store.py
@@ -37,11 +37,11 @@ def initialize():
     s = store.Store('postit.axiom')
     postit = IPostit(s, None)
     if not postit:
-        Application(store=s, name=u'Postit').installOn(s)
+        Application(store=s, name='Postit').installOn(s)
         Post(store=s, 
-             title=u"This is the title",
-             url=u"http://www.divmod.org",
-             content=u"Here is the content for the link",
-             author=u"dialtone",
+             title="This is the title",
+             url="http://www.divmod.org",
+             content="Here is the content for the link",
+             author="dialtone",
              created=Time())
     return s

--- a/examples/postit/store.py
+++ b/examples/postit/store.py
@@ -1,4 +1,4 @@
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from axiom import item, store
 from axiom.attributes import text, timestamp
@@ -18,8 +18,8 @@ class Post(item.Item):
     author = text()
     created = timestamp()
 
+@implementer(IPostit)
 class Application(item.Item, item.InstallableMixin):
-    implements(IPostit)
 
     name = text()
 

--- a/examples/todo/controller.py
+++ b/examples/todo/controller.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import rend, loaders, tags as t
 from formless import annotate, webform
@@ -21,8 +21,8 @@ class ITodo(annotate.TypedInterface):
         pass
     update = annotate.autocallable(update, invisible=True)
 
+@implementer(ITodo)
 class Root(rend.Page):
-    implements(ITodo)
     
     child_css = webform.defaultCSS
     

--- a/examples/todo/dispatcher.py
+++ b/examples/todo/dispatcher.py
@@ -1,6 +1,7 @@
 from nevow import rend
 import itodo
 import controller
+import imp
 
 # All this is only useful to dynamically update the web page code
 # without restarting the server each time. As you can see below, you can 
@@ -9,5 +10,5 @@ import controller
 class Dispatch(rend.Page):
     def locateChild(self, ctx, segments):
         if itodo.IEnv(ctx).development:
-            reload(controller)
+            imp.reload(controller)
         return controller.root.locateChild(ctx,segments)

--- a/examples/todo/store.py
+++ b/examples/todo/store.py
@@ -1,9 +1,9 @@
-from zope.interface import implements
+from zope.interface import implementer
 import pgasync
 import itodo
 
+@implementer(itodo.ITodos)
 class Todos(object):
-    implements(itodo.ITodos)
     def __init__(self, dbname, user, password, host):
         self.original = pgasync.ConnectionPool("pgasync", dbname=dbname, 
                         user=user, password=password, host=host)

--- a/examples/tree/tree.py
+++ b/examples/tree/tree.py
@@ -13,7 +13,7 @@ class Tree(dict):
             self.add(child)
     def add(self, child):
         self[child.name] = child
-    def __nonzero__(self):
+    def __bool__(self):
         return True
  
 class ITreeEdit(annotate.TypedInterface):
@@ -55,7 +55,7 @@ class TreeRenderer(rend.Page):
     def data_description(self, context, data):
         return self.original.description
     def data_children(self, context, data):
-        return self.original.items()
+        return list(self.original.items())
     def render_childLink(self, context, data):
         return T.a(href='subtree_%s/'%data[0])[data[1].description]
     def childFactory(self, ctx, name):
@@ -63,7 +63,8 @@ class TreeRenderer(rend.Page):
             return self.original[name[len('subtree_'):]]
     def render_descriptionForm(self, context, data):
         return webform.renderForms()
-    def render_childDel(self, context, (name, _)):
+    def render_childDel(self, context, xxx_todo_changeme):
+        (name, _) = xxx_todo_changeme
         ret = T.form(action="./freeform_post!!deleteChild",
                      enctype="multipart/form-data", method="POST")[
                T.input(type="hidden", name="name", value=name),

--- a/examples/tree/tree.py
+++ b/examples/tree/tree.py
@@ -31,7 +31,7 @@ class ITreeEdit(annotate.TypedInterface):
 @implementer(ITreeEdit)
 class TreeRenderer(rend.Page):
     addSlash = True
-    docFactory = loaders.htmlstr("""
+    docFactory = loaders.xmlstr("""
 <html>
 <head><title>Tree Editor</title></head>
 <body><h1><span nevow:data="description"

--- a/examples/tree/tree.py
+++ b/examples/tree/tree.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python.components import registerAdapter
 
@@ -28,8 +28,8 @@ class ITreeEdit(annotate.TypedInterface):
         pass
     addChild = annotate.autocallable(addChild)
  
+@implementer(ITreeEdit)
 class TreeRenderer(rend.Page):
-    implements(ITreeEdit)
     addSlash = True
     docFactory = loaders.htmlstr("""
 <html>

--- a/examples/userdb/userdb.tac
+++ b/examples/userdb/userdb.tac
@@ -1,7 +1,7 @@
 import string
 import urllib
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import defer
 from twisted.python import failure
@@ -173,8 +173,8 @@ class NotLoggedIn(rend.Page):
         ]
     ])
 
+@implementer(ILogout)
 class Logout(rend.Page):
-    implements(ILogout)
 
     def logout(self, request):
         request.getSession().expire()
@@ -182,8 +182,8 @@ class Logout(rend.Page):
 
     docFactory = loaders.stan(html[webform.renderForms()])
 
+@implementer(IEditUser, IDeleteUser)
 class UserPage(rend.Page):
-    implements(IEditUser, IDeleteUser)
 
     def __init__(self, user):
         rend.Page.__init__(self)
@@ -295,8 +295,8 @@ class UserPage(rend.Page):
     ]
     ])
 
+@implementer(ICreateUser)
 class UserBrowserPage(rend.Page):
-    implements(ICreateUser)
 
     addSlash = True
     

--- a/examples/with_axiom/powerups.py
+++ b/examples/with_axiom/powerups.py
@@ -28,16 +28,16 @@ class Library(item.Item, item.InstallableMixin):
         newBook = Book(store=self.store, title=title)
     
     def getBookByTitle(self, title):
-        books = self.store.query(Book, Book.title == unicode(title))
+        books = self.store.query(Book, Book.title == str(title))
         for book in books:
             return book
         
 def initialize(dbdir):
     # This is store initialization. 
     s = store.Store(dbdir)
-    l = Library(store=s, name=u"Great Library")
+    l = Library(store=s, name="Great Library")
     l.installOn(s)
-    descr = u"""This book is totally useless, in fact nobody would
+    descr = """This book is totally useless, in fact nobody would
     borrow it"""
-    Book(store=s, title=u"Title: 1", description=descr)
+    Book(store=s, title="Title: 1", description=descr)
     return s

--- a/examples/with_axiom/powerups.py
+++ b/examples/with_axiom/powerups.py
@@ -1,4 +1,4 @@
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from axiom import store, item, attributes
 
@@ -12,8 +12,8 @@ class Book(item.Item):
 class ILibrary(Interface):
     pass
 
+@implementer(ILibrary)
 class Library(item.Item, item.InstallableMixin):
-    implements(ILibrary)
     
     typeName = 'library'
     schemaVersion = 1

--- a/formless/annotate.py
+++ b/formless/annotate.py
@@ -813,8 +813,8 @@ class MetaTypedInterface(InterfaceClass):
                 )
         for attacher in actionAttachers:
             attacher.attachActionBindings(possibleActions)
-        methods.sort(_sorter)
-        properties.sort(_sorter)
+        methods.sort(key=_sorter)
+        properties.sort(key=_sorter)
         cls.__spec__ = spec = methods + properties
         spec.sort(_sorter)
         cls.name = name

--- a/formless/annotate.py
+++ b/formless/annotate.py
@@ -10,7 +10,7 @@ import os
 import sys
 import inspect
 import warnings
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface.interface import InterfaceClass, Attribute
 
 from nevow import util
@@ -359,8 +359,8 @@ class Object(Typed):
 
 
 
+@implementer(iformless.IActionableType)
 class List(Object):
-    implements(iformless.IActionableType)
 
     complexType = True
     def __init__(self, actions=None, header='', footer='', separator='', *args, **kw):
@@ -489,7 +489,7 @@ def autocallable(method, action=None, visible=False, **kw):
 ## what names are bound to what types
 #######################################
 
-
+@implementer(iformless.IBinding)
 class Binding(object):
     """Bindings bind a Typed instance to a name. When TypedInterface is subclassed,
     the metaclass looks through the dict looking for all properties and methods.
@@ -509,7 +509,6 @@ class Binding(object):
     Binding when it is constructed to keep track of what the method is
     supposed to return.
     """
-    implements(iformless.IBinding)
 
     label = None
     description = ''

--- a/formless/annotate.py
+++ b/formless/annotate.py
@@ -620,8 +620,8 @@ class GroupBinding(Binding):
         print("CONFIGURING GROUP BINDING", boundTo, group)
 
 
-def _sorter(x, y):
-    return cmp(x.id, y.id)
+def _sorter(x):
+    return x.id
 
 
 class _Marker(object):

--- a/formless/annotate.py
+++ b/formless/annotate.py
@@ -70,6 +70,7 @@ class ValidateError(Exception):
 
 
 
+@implementer(iformless.ITyped)
 class Typed(Attribute):
     """A typed value. Subclasses of Typed are constructed inside of
     TypedInterface class definitions to describe the types of properties,
@@ -93,7 +94,6 @@ class Typed(Attribute):
         of the data from the browser and pass unicode strings to
         coerce.
     """
-    implements(iformless.ITyped)
 
     complexType = False
     strip = False

--- a/formless/annotate.py
+++ b/formless/annotate.py
@@ -816,7 +816,7 @@ class MetaTypedInterface(InterfaceClass):
         methods.sort(key=_sorter)
         properties.sort(key=_sorter)
         cls.__spec__ = spec = methods + properties
-        spec.sort(_sorter)
+        spec.sort(key=_sorter)
         cls.name = name
 
         # because attributes "label" and "description" would become Properties,

--- a/formless/annotate.py
+++ b/formless/annotate.py
@@ -17,16 +17,17 @@ from nevow import util
 
 
 from formless import iformless
+import collections
 
 
 class count(object):
     def __init__(self):
         self.id = 0
-    def next(self):
+    def __next__(self):
         self.id += 1
         return self.id
 
-nextId = count().next
+nextId = count().__next__
 
 
 class InputError(Exception):
@@ -102,7 +103,7 @@ class Typed(Attribute):
     required = False
     requiredFailMessage = 'Please enter a value'
     null = None
-    unicode = False
+    str = False
 
     __name__ = ''
 
@@ -114,7 +115,7 @@ class Typed(Attribute):
         required=None,
         requiredFailMessage=None,
         null=None,
-        unicode=None,
+        str=None,
         **attributes):
 
         self.id = nextId()
@@ -130,15 +131,15 @@ class Typed(Attribute):
             self.requiredFailMessage = requiredFailMessage
         if null is not None:
             self.null = null
-        if unicode is not None:
-            self.unicode = unicode
+        if str is not None:
+            self.str = str
         self.attributes = attributes
 
     def getAttribute(self, name, default=None):
         return self.attributes.get(name, default)
 
     def coerce(self, val, configurable):
-        raise NotImplementedError, "Implement in %s" % util.qual(self.__class__)
+        raise NotImplementedError("Implement in %s" % util.qual(self.__class__))
 
 
 #######################################
@@ -209,7 +210,7 @@ class Integer(Typed):
         except ValueError:
             if sys.version_info < (2,3): # Long/Int aren't integrated
                 try:
-                    return long(val)
+                    return int(val)
                 except ValueError:
                     raise InputError("'%s' is not an integer." % val)
             
@@ -540,7 +541,7 @@ class Binding(object):
         return self.original.__class__.__name__.lower()
 
     def configure(self, boundTo, results):
-        raise NotImplementedError, "Implement in %s" % util.qual(self.__class__)
+        raise NotImplementedError("Implement in %s" % util.qual(self.__class__))
 
     def coerce(self, val, configurable):
         if hasattr(self.original, 'coerce'):
@@ -617,7 +618,7 @@ class GroupBinding(Binding):
         self.complexType = typedValue.complexType
 
     def configure(self, boundTo, group):
-        print "CONFIGURING GROUP BINDING", boundTo, group
+        print("CONFIGURING GROUP BINDING", boundTo, group)
 
 
 def _sorter(x, y):
@@ -670,7 +671,7 @@ def nameToLabel(mname):
 def labelAndDescriptionFromDocstring(docstring):
     if docstring is None:
         docstring = ''
-    docs = filter(lambda x: x, [x.strip() for x in docstring.split('\n')])
+    docs = [x for x in [x.strip() for x in docstring.split('\n')] if x]
     if len(docs) > 1:
         return docs[0], '\n'.join(docs[1:])
     else:
@@ -723,7 +724,7 @@ class MetaTypedInterface(InterfaceClass):
         cls.complexType = True
         possibleActions = []
         actionAttachers = []
-        for key, value in dct.items():
+        for key, value in list(dct.items()):
             if key[0] == '_': continue
 
             if isinstance(value, MetaTypedInterface):
@@ -733,7 +734,7 @@ class MetaTypedInterface(InterfaceClass):
                 ## zope.interface doesn't like these
                 del dct[key]
                 setattr(cls, key, value)
-            elif callable(value):
+            elif isinstance(value, collections.Callable):
                 names, _, _, typeList = inspect.getargspec(value)
 
                 _testCallArgs = ()

--- a/formless/configurable.py
+++ b/formless/configurable.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from zope.interface import implements, providedBy
+from zope.interface import implementer, providedBy
 
 from formless.iformless import IConfigurable, IActionableType, IBinding
 from formless.annotate import Argument, ElementBinding, GroupBinding, Object, TypedInterface
@@ -9,8 +9,8 @@ from formless.annotate import Argument, ElementBinding, GroupBinding, Object, Ty
 from nevow import inevow
 from nevow.context import WovenContext
 
+@implementer(IConfigurable)
 class Configurable(object):
-    implements(IConfigurable)
 
     bindingDict = None
 

--- a/formless/configurable.py
+++ b/formless/configurable.py
@@ -66,7 +66,7 @@ class Configurable(object):
             try:
                 binding = self.bindingDict[name]
             except KeyError:
-                raise RuntimeError, "%s is not an exposed binding on object %s." % (name, self.boundTo)
+                raise RuntimeError("%s is not an exposed binding on object %s." % (name, self.boundTo))
         binding.boundTo = self.boundTo
         return binding
 
@@ -125,7 +125,7 @@ class Configurable(object):
 
 class NotFoundConfigurable(Configurable):
     def getBinding(self, context, name):
-        raise RuntimeError, self.original
+        raise RuntimeError(self.original)
 
 
 class TypedInterfaceConfigurable(Configurable):

--- a/formless/formutils.py
+++ b/formless/formutils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from __future__ import generators
+
 
 from zope.interface import implements
 
@@ -20,7 +20,7 @@ except:
         i = 0
         it = iter(collection)
         while 1:
-            yield (i, it.next())
+            yield (i, next(it))
             i += 1
 
 
@@ -48,7 +48,7 @@ class PrefixerDict(dict):
         return self.errors[pfxkey]
 
     def update(self, other):
-        for key, value in other.items():
+        for key, value in list(other.items()):
             self[key] = value
 
 
@@ -107,7 +107,7 @@ class FormErrors(components.Adapter):
         PrefixerDict(formName, self.errors).update(errors)
 
     def clearErrors(self, formName):
-        for key in self.errors.keys():
+        for key in list(self.errors.keys()):
             if key.startswith(formName):
                 del self.errors[key]
 

--- a/formless/formutils.py
+++ b/formless/formutils.py
@@ -3,7 +3,7 @@
 
 
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python import components
 
@@ -85,11 +85,11 @@ class FormDefaults(components.Adapter):
     def clearAll(self):
         self.defaults = {}
 
-
+@implementer(iformless.IFormErrors)
 class FormErrors(components.Adapter):
     """An object which keeps track of which forms have which errors
     """
-    implements(iformless.IFormErrors)
+    
     def __init__(self):
         self.errors = {}
 

--- a/formless/processors.py
+++ b/formless/processors.py
@@ -21,7 +21,7 @@ faketag = tags.html()
 def exceptblock(f, handler, exception, *a, **kw):
     try:
         result = f(*a, **kw)
-    except exception, e:
+    except exception as e:
         return handler(e)
     if isinstance(result, Deferred):
         def _(fail):
@@ -91,7 +91,7 @@ class ProcessMethodBinding(components.Adapter):
         typedValue = self.original.typedValue
         results = {}
         failures = {}
-        if data.has_key('----'):
+        if '----' in data:
             ## ---- is the "direct object", the one argument you can specify using the command line without saying what the argument name is
             data[typedValue.arguments[0].name] = data['----']
             del data['----']
@@ -101,7 +101,7 @@ class ProcessMethodBinding(components.Adapter):
                 context = WovenContext(context, faketag)
                 context.remember(binding, iformless.IBinding)
                 results[name] = iformless.IInputProcessor(binding.typedValue).process(context, boundTo, data.get(name, ['']))
-            except formless.InputError, e:
+            except formless.InputError as e:
                 results[name] = data.get(name, [''])[0]
                 failures[name] = e.reason
 
@@ -130,14 +130,14 @@ class ProcessPropertyBinding(components.Adapter):
         result = {}
         try:
             result[binding.name] = iformless.IInputProcessor(binding.typedValue).process(context, boundTo, data.get(binding.name, ['']))
-        except formless.InputError, e:
+        except formless.InputError as e:
             result[binding.name] = data.get(binding.name, [''])
             raise formless.ValidateError({binding.name: e.reason}, e.reason, result)
 
         if autoConfigure:
             try:
                 return self.original.configure(boundTo, result)
-            except formless.InputError, e:
+            except formless.InputError as e:
                 result[binding.name] = data.get(binding.name, [''])
                 raise formless.ValidateError({binding.name: e.reason}, e.reason, result)
         return result
@@ -150,7 +150,7 @@ class ProcessTyped(components.Adapter):
         """
         typed = self.original
         val = data[0]
-        if typed.unicode:
+        if typed.str:
             try:
                 val = val.decode(getPOSTCharset(context), 'replace')
             except LookupError:
@@ -164,7 +164,7 @@ class ProcessTyped(components.Adapter):
                 return typed.null
         try:
             return typed.coerce(val, boundTo)
-        except TypeError, e:
+        except TypeError as e:
             warnings.warn('Typed.coerce takes two values now, the value to coerce and the configurable in whose context the coerce is taking place. %s %s' % (typed.__class__, typed))
             return typed.coerce(val)
 
@@ -190,7 +190,7 @@ class ProcessPassword(components.Adapter):
             else:
                 return typed.null
         val = data[0]
-        if typed.unicode:
+        if typed.str:
             try:
                 val = val.decode(getPOSTCharset(context), 'replace')
             except LookupError:

--- a/formless/processors.py
+++ b/formless/processors.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 import warnings
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python import components
 
@@ -31,9 +31,8 @@ def exceptblock(f, handler, exception, *a, **kw):
     else:
         return result
 
-    
+@implementer(iformless.IInputProcessor)
 class ProcessGroupBinding(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data):
         ## THE SPEC: self.original.typedValue.iface.__spec__
@@ -79,8 +78,8 @@ class ProcessGroupBinding(components.Adapter):
                 raise formless.ValidateError(failures, 'Error:', results)
         return DeferredList(waiters).addBoth(_finish)
 
+@implementer(iformless.IInputProcessor)
 class ProcessMethodBinding(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data, autoConfigure = True):
         """Knows how to process a dictionary of lists
@@ -117,8 +116,8 @@ class ProcessMethodBinding(components.Adapter):
                                boundTo, results)
         return results
 
+@implementer(iformless.IInputProcessor)
 class ProcessPropertyBinding(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data, autoConfigure = True):
         """Knows how to process a dictionary of lists
@@ -142,8 +141,8 @@ class ProcessPropertyBinding(components.Adapter):
                 raise formless.ValidateError({binding.name: e.reason}, e.reason, result)
         return result
 
+@implementer(iformless.IInputProcessor)
 class ProcessTyped(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data):
         """data is a list of strings at this point
@@ -168,8 +167,8 @@ class ProcessTyped(components.Adapter):
             warnings.warn('Typed.coerce takes two values now, the value to coerce and the configurable in whose context the coerce is taking place. %s %s' % (typed.__class__, typed))
             return typed.coerce(val)
 
+@implementer(iformless.IInputProcessor)
 class ProcessPassword(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data):
         """Password needs to look at two passwords in the data,
@@ -201,22 +200,21 @@ class ProcessPassword(components.Adapter):
             warnings.warn('Typed.coerce takes two values now, the value to coerce and the configurable in whose context the coerce is taking place. %s %s' % (typed.__class__, typed))
             return typed.coerce(data[0])
 
+
+@implementer(iformless.IInputProcessor)
 class ProcessRequest(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data):
         return context.locate(inevow.IRequest)
 
-
+@implementer(iformless.IInputProcessor)
 class ProcessContext(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data):
         return context
 
-
+@implementer(iformless.IInputProcessor)
 class ProcessUpload(components.Adapter):
-    implements(iformless.IInputProcessor)
 
     def process(self, context, boundTo, data):
 

--- a/formless/test/test_formless.py
+++ b/formless/test/test_formless.py
@@ -16,60 +16,60 @@ def process(typed, value):
 class Typed(TestCase):
     def testString(self):
         s = formless.String()
-        self.assertEquals(process(s, ''), None)
-        self.assertEquals(process(s, "Fooo"), "Fooo")
-        self.assertEquals(process(s, "This is a string"), "This is a string")
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
+        self.assertEqual(process(s, ''), None)
+        self.assertEqual(process(s, "Fooo"), "Fooo")
+        self.assertEqual(process(s, "This is a string"), "This is a string")
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
 
-        s = formless.String(unicode=True)
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), u'C\u00e9sar')
+        s = formless.String(str=True)
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\u00e9sar')
 
         s = formless.String(required=True)
         self.assertRaises(formless.InputError, process, s, "")
         
         s = formless.String(required=False)
-        self.assertEquals(process(s, "Bar"), "Bar")
-        self.assertEquals(process(s, ""), None)
+        self.assertEqual(process(s, "Bar"), "Bar")
+        self.assertEqual(process(s, ""), None)
     
         s = formless.String()
-        self.assertEquals(process(s, ' abc '), ' abc ')
+        self.assertEqual(process(s, ' abc '), ' abc ')
         
         s = formless.String(strip=True, required=True)
-        self.assertEquals(process(s, ' abc '), 'abc')
-        self.assertEquals(process(s, '\t abc \t  \n '), 'abc')
+        self.assertEqual(process(s, ' abc '), 'abc')
+        self.assertEqual(process(s, '\t abc \t  \n '), 'abc')
         self.assertRaises(formless.InputError, process, s, ' ')
         
         s = formless.String(required=False, strip=True)
-        self.assertEquals(process(s, ' abc '), 'abc')
-        self.assertEquals(process(s, ' '), None)
+        self.assertEqual(process(s, ' abc '), 'abc')
+        self.assertEqual(process(s, ' '), None)
         
     def testText(self):
         s = formless.Text()
-        self.assertEquals(process(s, ""), None)
-        self.assertEquals(process(s, "Fooo"), "Fooo")
-        self.assertEquals(process(s, "This is a string"), "This is a string")
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
+        self.assertEqual(process(s, ""), None)
+        self.assertEqual(process(s, "Fooo"), "Fooo")
+        self.assertEqual(process(s, "This is a string"), "This is a string")
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
 
-        s = formless.Text(unicode=True)
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), u'C\u00e9sar')
+        s = formless.Text(str=True)
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\u00e9sar')
 
         s = formless.Text(required=True)
         self.assertRaises(formless.InputError, process, s, "")
         
         s = formless.Text(required=False)
-        self.assertEquals(process(s, "Bar"), "Bar")
-        self.assertEquals(process(s, ""), None)
+        self.assertEqual(process(s, "Bar"), "Bar")
+        self.assertEqual(process(s, ""), None)
         
         s = formless.Text()
-        self.assertEquals(process(s, ' abc '), ' abc ')
+        self.assertEqual(process(s, ' abc '), ' abc ')
         
         s = formless.Text(strip=True, required=True)
-        self.assertEquals(process(s, ' abc '), 'abc')
+        self.assertEqual(process(s, ' abc '), 'abc')
         self.assertRaises(formless.InputError, process, s, ' ')
         
         s = formless.Text(required=False, strip=True)
-        self.assertEquals(process(s, ' abc '), 'abc')
-        self.assertEquals(process(s, ' '), None)
+        self.assertEqual(process(s, ' abc '), 'abc')
+        self.assertEqual(process(s, ' '), None)
         
     def testPassword(self):
 
@@ -80,64 +80,64 @@ class Typed(TestCase):
                 {'password': [val], 'password____2': [val2]})['password']
 
         s = formless.Password()
-        self.assertEquals(process(s, "Fooo"), "Fooo")
-        self.assertEquals(process(s, "This is a string"), "This is a string")
-        self.assertEquals(process(s, "This is a string"), "This is a string")
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
+        self.assertEqual(process(s, "Fooo"), "Fooo")
+        self.assertEqual(process(s, "This is a string"), "This is a string")
+        self.assertEqual(process(s, "This is a string"), "This is a string")
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
 
-        s = formless.Password(unicode=True)
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), u'C\u00e9sar')
+        s = formless.Password(str=True)
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\u00e9sar')
 
         s = formless.Password(required=True)
         self.assertRaises(formless.ValidateError, process, s, "")
         
         s = formless.Password(required=False)
-        self.assertEquals(process(s, "Bar"), "Bar")
-        self.assertEquals(process(s, ""), None)
+        self.assertEqual(process(s, "Bar"), "Bar")
+        self.assertEqual(process(s, ""), None)
     
         s = formless.Password()
-        self.assertEquals(process(s, ' abc '), ' abc ')
+        self.assertEqual(process(s, ' abc '), ' abc ')
         
         s = formless.Password(strip=True, required=True)
-        self.assertEquals(process(s, ' abc '), 'abc')
+        self.assertEqual(process(s, ' abc '), 'abc')
         self.assertRaises(formless.ValidateError, process, s, ' ')
         
         s = formless.Password(required=False, strip=True)
-        self.assertEquals(process(s, ' abc '), 'abc')
-        self.assertEquals(process(s, ' '), None)
+        self.assertEqual(process(s, ' abc '), 'abc')
+        self.assertEqual(process(s, ' '), None)
         
     def testPasswordEntry(self):
         s = formless.PasswordEntry()
-        self.assertEquals(process(s, ''), None)
-        self.assertEquals(process(s, 'abc'), 'abc')
-        self.assertEquals(process(s, ' blah blah blah  '), ' blah blah blah  ')
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
+        self.assertEqual(process(s, ''), None)
+        self.assertEqual(process(s, 'abc'), 'abc')
+        self.assertEqual(process(s, ' blah blah blah  '), ' blah blah blah  ')
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\xc3\xa9sar')
 
-        s = formless.PasswordEntry(unicode=True)
-        self.assertEquals(process(s, 'C\xc3\xa9sar'), u'C\u00e9sar')
+        s = formless.PasswordEntry(str=True)
+        self.assertEqual(process(s, 'C\xc3\xa9sar'), 'C\u00e9sar')
 
         s = formless.PasswordEntry(strip=True)
-        self.assertEquals(process(s, ''), None)
-        self.assertEquals(process(s, 'abc'), 'abc')
-        self.assertEquals(process(s, ' blah blah blah  '), 'blah blah blah')
+        self.assertEqual(process(s, ''), None)
+        self.assertEqual(process(s, 'abc'), 'abc')
+        self.assertEqual(process(s, ' blah blah blah  '), 'blah blah blah')
 
         s = formless.PasswordEntry(strip=True, required=True)
         self.assertRaises(formless.InputError, process, s, '')
         self.assertRaises(formless.InputError, process, s, '   ')
-        self.assertEquals(process(s, 'abc'), 'abc')
-        self.assertEquals(process(s, ' blah blah blah  '), 'blah blah blah')
+        self.assertEqual(process(s, 'abc'), 'abc')
+        self.assertEqual(process(s, ' blah blah blah  '), 'blah blah blah')
         
     def testInteger(self):
         i = formless.Integer(required=True)
-        self.assertEquals(process(i, "0"), 0)
-        self.assertEquals(process(i, "3409823098"), 3409823098)
+        self.assertEqual(process(i, "0"), 0)
+        self.assertEqual(process(i, "3409823098"), 3409823098)
         self.assertRaises(formless.InputError, process, i, "")
         self.assertRaises(formless.InputError, process, i, "a string")
         self.assertRaises(formless.InputError, process, i, "1.5")
         
         i = formless.Integer(required=False)
-        self.assertEquals(process(i, "1234567"), 1234567)
-        self.assertEquals(process(i, ""), None)
+        self.assertEqual(process(i, "1234567"), 1234567)
+        self.assertEqual(process(i, ""), None)
         
     def testReal(self):
         i = formless.Real(required=True)
@@ -149,7 +149,7 @@ class Typed(TestCase):
 
         i = formless.Real(required=False)
         self.assertApproximates(process(i, "1234.567"), 1234.567, 1e-10)
-        self.assertEquals(process(i, ""), None)
+        self.assertEqual(process(i, ""), None)
 
     def testBoolean(self):
         b = formless.Boolean(required=True)
@@ -157,19 +157,19 @@ class Typed(TestCase):
         self.assertRaises(formless.InputError, process, b, True)
         self.assertRaises(formless.InputError, process, b, 54)
         self.assertRaises(formless.InputError, process, b, "")
-        self.assertEquals(process(b, "True"), True)
-        self.assertEquals(process(b, "False"), False)
+        self.assertEqual(process(b, "True"), True)
+        self.assertEqual(process(b, "False"), False)
 
         b = formless.Boolean(required=False)
         self.assertRaises(formless.InputError, process, b, "zoom")
-        self.assertEquals(process(b, ""), None)
-        self.assertEquals(process(b, "True"), True)
-        self.assertEquals(process(b, "False"), False)
+        self.assertEqual(process(b, ""), None)
+        self.assertEqual(process(b, "True"), True)
+        self.assertEqual(process(b, "False"), False)
         
     def testFixedDigitInteger(self):
         d = formless.FixedDigitInteger(3, required=True)
-        self.assertEquals(process(d, "123"), 123)
-        self.assertEquals(process(d, "567"), 567)
+        self.assertEqual(process(d, "123"), 123)
+        self.assertEqual(process(d, "567"), 567)
         self.assertRaises(formless.InputError, process, d, "12")
         self.assertRaises(formless.InputError, process, d, "1234")
         self.assertRaises(formless.InputError, process, d, "012")
@@ -178,9 +178,9 @@ class Typed(TestCase):
         self.assertRaises(formless.InputError, process, d, "")
 
         d = formless.FixedDigitInteger(3, required=False)
-        self.assertEquals(process(d, "123"), 123)
+        self.assertEqual(process(d, "123"), 123)
         self.assertRaises(formless.InputError, process, d, "foo")
-        self.assertEquals(process(d, ""), None)
+        self.assertEqual(process(d, ""), None)
 
     def testDirectory(self):
         p1 = self.mktemp()
@@ -188,14 +188,14 @@ class Typed(TestCase):
         p2 = self.mktemp()
         
         d = formless.Directory(required=True)
-        self.assertEquals(process(d, p1), p1)
+        self.assertEqual(process(d, p1), p1)
         self.assertRaises(formless.InputError, process, d, p2)
         self.assertRaises(formless.InputError, process, d, "")
         
         d = formless.Directory(required=False)
-        self.assertEquals(process(d, p1), p1)
+        self.assertEqual(process(d, p1), p1)
         self.assertRaises(formless.InputError, process, d, p2)
-        self.assertEquals(process(d, ""), None)
+        self.assertEqual(process(d, ""), None)
 
 
 class Annotation(TestCase):
@@ -209,20 +209,20 @@ class Annotation(TestCase):
             baz = formless.Integer()
             quux = formless.Object(interface=_indirectOther())
 
-        self.assertEquals(Test.__properties__, Test.__spec__)
+        self.assertEqual(Test.__properties__, Test.__spec__)
 
         bfoo, bbar, bbaz, quux = Test.__properties__
 
-        self.assertEquals(bfoo.name, 'foo')
-        self.assertEquals(bbar.name, 'bar')
-        self.assertEquals(bbaz.name, 'baz')
+        self.assertEqual(bfoo.name, 'foo')
+        self.assertEqual(bbar.name, 'bar')
+        self.assertEqual(bbaz.name, 'baz')
 
-        self.assertEquals(bfoo.typedValue.__class__, formless.String)
-        self.assertEquals(bbar.typedValue.__class__, formless.Text)
-        self.assertEquals(bbaz.typedValue.__class__, formless.Integer)
-        self.assertEquals(quux.typedValue.__class__, formless.Object)
+        self.assertEqual(bfoo.typedValue.__class__, formless.String)
+        self.assertEqual(bbar.typedValue.__class__, formless.Text)
+        self.assertEqual(bbaz.typedValue.__class__, formless.Integer)
+        self.assertEqual(quux.typedValue.__class__, formless.Object)
 
-        self.assertEquals(quux.typedValue.iface, Other)
+        self.assertEqual(quux.typedValue.iface, Other)
 
 
     def testTypedInterfaceMethods(self):
@@ -249,47 +249,47 @@ class Annotation(TestCase):
                 return IFoo
             baz = formless.autocallable(baz)
 
-        self.assertEquals(Test2.__methods__, Test2.__spec__)
+        self.assertEqual(Test2.__methods__, Test2.__spec__)
 
         bfoo, bbar, bbaz = Test2.__methods__
 
-        self.assertEquals(bfoo.name, 'foo')
-        self.assertEquals(bbar.name, 'bar')
-        self.assertEquals(bbar.getAttribute('someAttribute'), "Hello")
-        self.assertEquals(bbaz.name, 'baz')
+        self.assertEqual(bfoo.name, 'foo')
+        self.assertEqual(bbar.name, 'bar')
+        self.assertEqual(bbar.getAttribute('someAttribute'), "Hello")
+        self.assertEqual(bbaz.name, 'baz')
 
-        self.assertEquals(bfoo.label, 'Foo')
-        self.assertEquals(bfoo.description, 'This is a description of foo')
+        self.assertEqual(bfoo.label, 'Foo')
+        self.assertEqual(bfoo.description, 'This is a description of foo')
 
-        self.assertEquals(bbar.label, 'Bar')
-        self.assertEquals(bbar.description, '')
+        self.assertEqual(bbar.label, 'Bar')
+        self.assertEqual(bbar.description, '')
 
-        self.assertEquals(bbaz.label, 'The Label')
-        self.assertEquals(bbaz.description, 'The description')
+        self.assertEqual(bbaz.label, 'The Label')
+        self.assertEqual(bbaz.description, 'The description')
 
         def getArgTypes(mbinding):
             return [x.typedValue.__class__ for x in mbinding.arguments]
 
-        self.assertEquals(getArgTypes(bfoo), [formless.String])
-        self.assertEquals(bfoo.returnValue.iface, None)
+        self.assertEqual(getArgTypes(bfoo), [formless.String])
+        self.assertEqual(bfoo.returnValue.iface, None)
 
-        self.assertEquals(getArgTypes(bbar), [formless.Integer])
-        self.assertEquals(bbar.returnValue.__class__, formless.String)
+        self.assertEqual(getArgTypes(bbar), [formless.Integer])
+        self.assertEqual(bbar.returnValue.__class__, formless.String)
 
-        self.assertEquals(getArgTypes(bbaz), [formless.Boolean])
-        self.assertEquals(bbaz.returnValue.iface, IFoo)
+        self.assertEqual(getArgTypes(bbaz), [formless.Boolean])
+        self.assertEqual(bbaz.returnValue.iface, IFoo)
 
         def firstArg(mbinding):
             return mbinding.arguments[0]
 
-        self.assertEquals(firstArg(bfoo).label, 'Foobar')
-        self.assertEquals(firstArg(bfoo).description, '')
+        self.assertEqual(firstArg(bfoo).label, 'Foobar')
+        self.assertEqual(firstArg(bfoo).description, '')
 
-        self.assertEquals(firstArg(bbar).label, 'The Baz')
-        self.assertEquals(firstArg(bbar).description, '')
+        self.assertEqual(firstArg(bbar).label, 'The Baz')
+        self.assertEqual(firstArg(bbar).description, '')
 
-        self.assertEquals(firstArg(bbaz).label, 'The Foo')
-        self.assertEquals(firstArg(bbaz).description, 'The foo to baz.')
+        self.assertEqual(firstArg(bbaz).label, 'The Foo')
+        self.assertEqual(firstArg(bbaz).description, 'The foo to baz.')
 
     def testTypedInterfaceMethods_actionLabel(self):
         """When no label was given, docstring is given preference compared to action."""
@@ -302,13 +302,13 @@ class Annotation(TestCase):
                 pass
             foo = formless.autocallable(foo, action="Do something!")
 
-        self.assertEquals(Test.__methods__, Test.__spec__)
+        self.assertEqual(Test.__methods__, Test.__spec__)
         (bfoo,) = Test.__methods__
 
-        self.assertEquals(bfoo.name, 'foo')
+        self.assertEqual(bfoo.name, 'foo')
 
-        self.assertEquals(bfoo.label, 'Label for foo')
-        self.assertEquals(bfoo.description, 'Description for foo')
+        self.assertEqual(bfoo.label, 'Label for foo')
+        self.assertEqual(bfoo.description, 'Description for foo')
 
     def testTypedInterfaceMethods_explicitLabel(self):
         """When a label was given, it is given preference compared to docstring."""
@@ -324,13 +324,13 @@ class Annotation(TestCase):
                                         label="Explicit label for foo",
                                         )
 
-        self.assertEquals(Test.__methods__, Test.__spec__)
+        self.assertEqual(Test.__methods__, Test.__spec__)
         (bfoo,) = Test.__methods__
 
-        self.assertEquals(bfoo.name, 'foo')
+        self.assertEqual(bfoo.name, 'foo')
 
-        self.assertEquals(bfoo.label, 'Explicit label for foo')
-        self.assertEquals(bfoo.description, 'Description for foo')
+        self.assertEqual(bfoo.label, 'Explicit label for foo')
+        self.assertEqual(bfoo.description, 'Description for foo')
 
     def testTypedInterfaceMethods_deprecated(self):
         class Test(formless.TypedInterface):
@@ -342,19 +342,19 @@ class Annotation(TestCase):
                 pass
             oneArg = formless.autocallable(oneArg)
 
-        self.assertEquals(Test.__methods__, Test.__spec__)
+        self.assertEqual(Test.__methods__, Test.__spec__)
         m_noArgs, m_oneArg = Test.__methods__
 
-        self.assertEquals(len(m_noArgs.arguments), 0)
-        self.assertEquals(len(m_oneArg.arguments), 1)
+        self.assertEqual(len(m_noArgs.arguments), 0)
+        self.assertEqual(len(m_oneArg.arguments), 1)
 
     def testTypedInterfaceMethods_nonAutocallable(self):
         class Test(formless.TypedInterface):
             def notAutocallable(arg1, arg2):
                 pass
 
-        self.assertEquals(Test.__methods__, Test.__spec__)
-        self.assertEquals(Test.__methods__, [])
+        self.assertEqual(Test.__methods__, Test.__spec__)
+        self.assertEqual(Test.__methods__, [])
 
 class IListWithActions(formless.TypedInterface):
     def actionOne(theSubset = formless.List()):
@@ -370,8 +370,8 @@ class TestListActions(TestCase):
         ## IListWithActions only has one binding, a Property binding
         ## of theListOfStuff to a List with some actions.
         actions = IListWithActions.__spec__[0].typedValue.actions
-        self.failUnless(reduce, (lambda x: x.name == 'actionOne', actions))
-        self.failUnless(reduce, (lambda x: x.name == 'actionTwo', actions))
+        self.assertTrue(reduce, (lambda x: x.name == 'actionOne', actions))
+        self.assertTrue(reduce, (lambda x: x.name == 'actionTwo', actions))
 
 
 class TestPropertyGroups(TestCase):
@@ -386,5 +386,5 @@ class TestPropertyGroups(TestCase):
                 """
                 anInnerProperty = formless.Integer()
 
-        self.assertEquals(Outer.__spec__[1].typedValue.iface, Outer.Inner)
+        self.assertEqual(Outer.__spec__[1].typedValue.iface, Outer.Inner)
         inn = Outer.__spec__[1].typedValue.iface

--- a/formless/test/test_freeform.py
+++ b/formless/test/test_freeform.py
@@ -285,7 +285,7 @@ class TestPostAForm(Base):
 
         D = self.postForm(ctx, theObj, "password", {"pword": ["these passwords"], "pword____2": ["don't match"], 'integer': ['Not integer']})
         def after(result):
-            self.assertEquals(theObj.matched, False)
+            self.assertEqual(theObj.matched, False)
             def later(val):
                 self.assertSubstring("Passwords do not match. Please reenter.", val)
                 self.assertSubstring('value="Not integer"', val)
@@ -344,10 +344,10 @@ class TestRenderPropertyGroup(Base):
 
             def after(result):
 
-                self.assertEquals(impl.one, 1)
-                self.assertEquals(impl.two, 2)
-                self.assertEquals(impl.buckled, False)
-                self.assertEquals(impl.buried, False)
+                self.assertEqual(impl.one, 1)
+                self.assertEqual(impl.two, 2)
+                self.assertEqual(impl.buckled, False)
+                self.assertEqual(impl.buried, False)
 
                 def evenlater(moreval):
                     self.assertSubstring("is not an integer", moreval)
@@ -355,10 +355,10 @@ class TestRenderPropertyGroup(Base):
                     #self.assertSubstring('value="Not an integer"', moreval)
                     DD = self.postForm(ctx, impl, "Inner", {'one': ['11'], 'two': ['22']})
                     def afterafter(ign):
-                        self.assertEquals(impl.one, 11)
-                        self.assertEquals(impl.two, 22)
-                        self.assertEquals(impl.buckled, True)
-                        self.assertEquals(impl.buried, True)
+                        self.assertEqual(impl.one, 11)
+                        self.assertEqual(impl.two, 22)
+                        self.assertEqual(impl.buckled, True)
+                        self.assertEqual(impl.buried, True)
                     return DD.addCallback(afterafter)
                 return self.renderForms(impl, ctx).addCallback(evenlater)
             return D.addCallback(after)
@@ -444,9 +444,9 @@ class TestCustomTyped(Base):
         ctx = self.setupContext()
         D = self.postForm(ctx, inst, 'theFunc', {'test': ['a test value']})
         def after(result):
-            self.assertEquals(typedinst.passed, True)
-            self.assertEquals(typedinst.wasBoundTo, inst)
-            self.assertEquals(inst.called, True)
+            self.assertEqual(typedinst.passed, True)
+            self.assertEqual(typedinst.wasBoundTo, inst)
+            self.assertEqual(inst.called, True)
         return D.addCallback(after)
 
 
@@ -513,8 +513,8 @@ class TestHandAndStatus(Base):
         ctx = self.setupContext()
         D = self.postForm(ctx, inst, 'foo', {})
         def after(result):
-            self.assertEquals(ctx.locate(inevow.IHand), returnResult)
-            self.assertEquals(ctx.locate(inevow.IStatusMessage), "'foo' success.")
+            self.assertEqual(ctx.locate(inevow.IHand), returnResult)
+            self.assertEqual(ctx.locate(inevow.IStatusMessage), "'foo' success.")
         return D.addCallback(after)
 
     def test_handFactory(self):
@@ -532,8 +532,8 @@ class TestHandAndStatus(Base):
             return r
         ctx = self.setupContext(setupRequest=setupRequest)
 
-        self.assertEquals(ctx.locate(inevow.IHand), returnResult)
-        self.assertEquals(ctx.locate(inevow.IStatusMessage), status)
+        self.assertEqual(ctx.locate(inevow.IHand), returnResult)
+        self.assertEqual(ctx.locate(inevow.IStatusMessage), status)
 
 
 class TestCharsetDetectionSupport(Base):
@@ -594,7 +594,7 @@ class TestUnicode(Base):
     def test_property(self):
 
         class IThing(formless.TypedInterface):
-            aString = formless.String(unicode=True)
+            aString = formless.String(str=True)
 
         class Impl(object):
             implements(IThing)
@@ -603,7 +603,7 @@ class TestUnicode(Base):
         inst = Impl()
         ctx = self.setupContext()
         D = self.postForm(ctx, inst, 'aString', {'aString':['\xc2\xa3']})
-        return D.addCallback(lambda result: self.assertEquals(inst.aString, u'\xa3'))
+        return D.addCallback(lambda result: self.assertEqual(inst.aString, '\xa3'))
 
 class TestChoice(Base):
     """Test various behaviors of submitting values to a Choice Typed.
@@ -628,7 +628,7 @@ class TestChoice(Base):
         inst = Impl()
         ctx = self.setupContext()
         D = self.postForm(ctx, inst, 'choiceyFunc', {})
-        return D.addCallback(lambda result: self.assertEquals(self.called, []))
+        return D.addCallback(lambda result: self.assertEqual(self.called, []))
 
 
 class mg(Base):
@@ -652,7 +652,7 @@ class mg(Base):
         impl = Impl()
         ctx = self.setupContext()
         def later(val):
-            self.assertEquals(val.count('fooFOOfoo'), 1)
+            self.assertEqual(val.count('fooFOOfoo'), 1)
         return self.renderForms(impl, ctx)
 
 

--- a/formless/test/test_freeform.py
+++ b/formless/test/test_freeform.py
@@ -17,8 +17,8 @@ from formless import configurable
 
 from nevow.test import test_flatstan
 
+@implementer(iformless.IConfigurableFactory)
 class Base(test_flatstan.Base):
-    implements(iformless.IConfigurableFactory)
 
     synchronousLocateConfigurable = False
 
@@ -68,9 +68,8 @@ class Complete(Base):
     def test_configureProperty(self):
         class IStupid(formless.TypedInterface):
             foo = formless.String()
-
+        @implementer(IStupid)
         class StupidThing(configurable.Configurable):
-            implements(IStupid)
 
             def __init__(self):
                 configurable.Configurable.__init__(self, None)
@@ -92,8 +91,8 @@ class Complete(Base):
                 return formless.String()
             foo = formless.autocallable(foo)
 
+        @implementer(IDumb)
         class DumbThing(configurable.Configurable):
-            implements(IDumb)
 
             def foo(self, bar):
                 return "baz"
@@ -184,8 +183,8 @@ class TestDefaults(Base):
         class IDefaultProperty(formless.TypedInterface):
             default = formless.Integer(default=2)
 
+        @implementer(IDefaultProperty)
         class Foo(configurable.Configurable):
-            implements(IDefaultProperty)
             default = 54
 
         def later(val):
@@ -200,8 +199,9 @@ class TestDefaults(Base):
         class Adaptee(object):
             default = 69
 
+        @implementer(IDefaultProperty)
         class Bar(configurable.Configurable):
-            implements(IDefaultProperty)
+            pass
 
         def later(val):
             self.failIfSubstring('2', val)
@@ -216,8 +216,9 @@ class TestDefaults(Base):
 
             aProperty = formless.String(default="The property")
 
+        @implementer(IBindingDefaults)
         class Implements(configurable.Configurable):
-            implements(IBindingDefaults)
+            pass
 
         def later(val):
             self.assertSubstring("The foo", val)
@@ -233,8 +234,9 @@ class TestDefaults(Base):
             aMethod = formless.autocallable(aMethod)
             bMethod = formless.autocallable(bMethod)
 
+        @implementer(IDynamicDefaults)
         class Implements(configurable.Configurable):
-            implements(IDynamicDefaults)
+            pass
 
         def later(val):
             self.assertSubstring("YESFOO", val)
@@ -255,8 +257,9 @@ class TestNonConfigurableSubclass(Base):
                 return None
             aMethod = formless.autocallable(aMethod)
 
+        @implementer(ISimpleTypedInterface)
         class ANonConfigurable(object): # Not subclassing Configurable
-            implements(ISimpleTypedInterface) # But implements a TypedInterface
+            pass
 
         def later(val):
             self.assertSubstring('anInt', val)
@@ -273,8 +276,8 @@ class TestPostAForm(Base):
                 pass
             password = formless.autocallable(password)
 
+        @implementer(IAPasswordMethod)
         class APasswordImplementation(object):
-            implements(IAPasswordMethod)
             matched = False
             def password(self, pword, integer):
                 self.matched = True
@@ -296,8 +299,8 @@ class TestPostAForm(Base):
         class IAProperty(formless.TypedInterface):
             prop = formless.Integer()
 
+        @implementer(IAProperty)
         class Impl(object):
-            implements(IAProperty)
             prop = 5
 
         theObj = Impl()
@@ -325,8 +328,8 @@ class TestRenderPropertyGroup(Base):
                     pass
                 buriedAlive = formless.autocallable(buriedAlive)
 
+        @implementer(Outer)
         class Implementation(object):
-            implements(Outer)
             one = 1
             two = 2
             buckled = False
@@ -373,8 +376,8 @@ class TestRenderMethod(Base):
                 pass
             foo = formless.autocallable(foo)
 
-        class Impl:
-            implements(IFoo)
+        @implementer(IFoo)
+        class Impl: pass
 
         def later(val):
             self.assertSubstring('value="Foo"', val)
@@ -389,8 +392,9 @@ class TestRenderMethod(Base):
                 pass
             foo = formless.autocallable(foo, action='FooFooFoo')
 
+        @implementer(IFoo)
         class Impl:
-            implements(IFoo)
+            pass
 
         def later(val):
             self.assertSubstring('value="FooFooFoo"', val)
@@ -405,8 +409,9 @@ class TestRenderMethod(Base):
             foo = formless.autocallable(sig)
             bar = formless.autocallable(sig, action='FooFooFOo')
 
+        @implementer(IFoo)
         class Impl:
-            implements(IFoo)
+            pass
 
         def later1(val):
             self.assertSubstring('value="Foo"', val)
@@ -434,8 +439,8 @@ class TestCustomTyped(Base):
                 pass
             theFunc = formless.autocallable(theFunc)
 
+        @implementer(IMyInterface)
         class Implementation(object):
-            implements(IMyInterface)
             called = False
             def theFunc(self, test):
                 self.called = True
@@ -455,8 +460,9 @@ class TestUneditableProperties(Base):
         class Uneditable(formless.TypedInterface):
             aProp = formless.String(description="the description", immutable=True)
 
+        @implementer(Uneditable)
         class Impl(object):
-            implements(Uneditable)
+            pass
 
             aProp = property(lambda self: "HELLO")
 
@@ -477,8 +483,8 @@ class TestAfterValidation(Base):
         class IThing(formless.TypedInterface):
             foo = formless.Integer()
 
+        @implementer(IThing)
         class Thing:
-            implements(IThing)
             foo = 1
 
         inst = Thing()
@@ -504,8 +510,8 @@ class TestHandAndStatus(Base):
             def foo(): pass
             foo = formless.autocallable(foo)
 
+        @implementer(IMethod)
         class Method(object):
-            implements(IMethod)
             def foo(self):
                 return returnResult
 
@@ -543,8 +549,9 @@ class TestCharsetDetectionSupport(Base):
         class ITest(formless.TypedInterface):
             foo = formless.String()
 
+        @implementer(ITest)
         class Impl:
-            implements(ITest)
+            pass
 
         impl = Impl()
         ctx = self.setupContext()
@@ -578,8 +585,9 @@ class TestCharsetDetectionSupport(Base):
                 pass
             foo = formless.autocallable(foo)
 
+        @implementer(ITest)
         class Impl:
-            implements(ITest)
+            pass
 
         impl = Impl()
         ctx = self.setupContext()
@@ -596,8 +604,8 @@ class TestUnicode(Base):
         class IThing(formless.TypedInterface):
             aString = formless.String(str=True)
 
+        @implementer(IThing)
         class Impl(object):
-            implements(IThing)
             aString = None
 
         inst = Impl()
@@ -619,8 +627,8 @@ class TestChoice(Base):
                 pass
             choiceyFunc = formless.autocallable(choiceyFunc)
 
+        @implementer(IFormyThing
         class Impl(object):
-            implements(IFormyThing)
 
             def choiceyFunc(innerSelf, arg):
                 self.called.append(arg)
@@ -645,8 +653,8 @@ class mg(Base):
                 pass
             meth = formless.autocallable(meth)
 
+        @implementer(ITest)
         class Impl:
-            implements(ITest)
             foo = 'fooFOOfoo'
 
         impl = Impl()

--- a/formless/webform.py
+++ b/formless/webform.py
@@ -4,7 +4,7 @@
 # See LICENSE for details.
 
 
-from __future__ import generators
+
 
 import warnings
 from zope.interface import implements, Interface
@@ -66,7 +66,7 @@ class BaseInputRenderer(components.Adapter):
         return context.tag
 
     def input(self, context, slot, data, name, value):
-        raise NotImplementedError, "Implement in subclass"
+        raise NotImplementedError("Implement in subclass")
 
 class PasswordRenderer(BaseInputRenderer):
     def input(self, context, slot, data, name, value):
@@ -437,7 +437,7 @@ def renderForms(configurableKey='', bindingNames=None, bindingDefaults=None):
             if bindingDefaults is None:
                 available = configurable.getBindingNames(context)
             else:
-                available = bindingDefaults.iterkeys()
+                available = iter(bindingDefaults.keys())
 
             def _callback(binding):
                 renderer = iformless.IBindingRenderer(binding, defaultBindingRenderer)

--- a/formless/webform.py
+++ b/formless/webform.py
@@ -7,7 +7,7 @@
 
 
 import warnings
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.python import components
 
@@ -25,18 +25,16 @@ from nevow.static import File
 
 defaultCSS = File(util.resource_filename('formless', 'freeform-default.css'), 'text/css')
 
-
+@implementer(inevow.IRenderer, iformless.ITypedRenderer)
 class DefaultRenderer(object):
-    implements(inevow.IRenderer, iformless.ITypedRenderer)
     complexType = False
     def rend(self, context, data):
         return StringRenderer(data)
 
 defaultBindingRenderer = DefaultRenderer()
 
-
+@implementer(inevow.IRenderer, iformless.ITypedRenderer)
 class BaseInputRenderer(components.Adapter):
-    implements(inevow.IRenderer, iformless.ITypedRenderer)
     complexType = False
     def rend(self, context, data):
         defaults = context.locate(iformless.IFormDefaults)
@@ -176,25 +174,22 @@ class RadioRenderer(ChoiceRenderer):
             tags.input(type="radio", name=slot('name'), value=valToKey, render=isChecked)[
                 lambda c, d: iformless.ITyped(c).stringify(d)]]]
 
-
+@implementer(inevow.IRenderer, iformless.ITypedRenderer)
 class ObjectRenderer(components.Adapter):
-    implements(inevow.IRenderer, iformless.ITypedRenderer)
     complexType = True
     def rend(self, context, data):
         configurable = context.locate(iformless.IConfigurable)
         return getattr(configurable, data.name)
-
+@implementer(inevow.IRenderer, iformless.ITypedRenderer)
 class NullRenderer(components.Adapter):
     """Use a NullRenderer as the ITypedRenderer adapter when nothing should
     be included in the output.
     """
-    implements(inevow.IRenderer, iformless.ITypedRenderer)
     def rend(self, context, data):
         return ''
 
-
+@implementer(inevow.IRenderer)
 class GroupBindingRenderer(components.Adapter):
-    implements(inevow.IRenderer)
 
     def rend(self, context, data):
         context.remember(data, iformless.IBinding)
@@ -229,9 +224,8 @@ class GroupBindingRenderer(components.Adapter):
                     generateBindings(),
                     tags.input(type="submit")]]
 
-
+@implementer(inevow.IRenderer)
 class BaseBindingRenderer(components.Adapter):
-    implements(inevow.IRenderer)
 
     isGrouped = False
     needsSkin = False
@@ -359,9 +353,8 @@ class MethodBindingRenderer(BaseBindingRenderer):
             context.fillSlots( 'argument!!%s' % argument.name, pat )
             yield pat
 
-
+@implementer(inevow.IRenderer)
 class ButtonRenderer(components.Adapter):
-    implements(inevow.IRenderer)
 
     def rend(self, context, data):
         return tags.input(id=keyToXMLID(context.key), type='submit', value=data.label, name=data.name, class_="freeform-button")

--- a/nevow/__init__.py
+++ b/nevow/__init__.py
@@ -2,6 +2,9 @@
 # Copyright (c) 2004-2006 Divmod.
 # See LICENSE for details.
 
+import types
+types.NoneType=type(None)
+
 from nevow._version import get_versions
 __version__ = get_versions()["version"]
 __version_info__ = tuple(int(part) for part in __version__.split("-", 1)[0].split(".")[:3])
@@ -158,7 +161,7 @@ nevow.flat.flatstan.XmlSerializer                 nevow.stan.xml
 nevow.flat.flatstan.RawSerializer                 nevow.stan.raw
 nevow.flat.flatstan.StringSerializer              builtins.str
 nevow.flat.flatstan.StringSerializer              builtins.bytes
-nevow.flat.flatstan.NoneWarningSerializer         builtins.NoneType
+nevow.flat.flatstan.NoneWarningSerializer         types.NoneType
 nevow.flat.flatstan.StringCastSerializer          builtins.int
 nevow.flat.flatstan.StringCastSerializer          builtins.float
 nevow.flat.flatstan.StringCastSerializer          builtins.long

--- a/nevow/__init__.py
+++ b/nevow/__init__.py
@@ -164,7 +164,6 @@ nevow.flat.flatstan.StringSerializer              builtins.bytes
 nevow.flat.flatstan.NoneWarningSerializer         types.NoneType
 nevow.flat.flatstan.StringCastSerializer          builtins.int
 nevow.flat.flatstan.StringCastSerializer          builtins.float
-nevow.flat.flatstan.StringCastSerializer          builtins.long
 nevow.flat.flatstan.BooleanSerializer          builtins.bool
 nevow.flat.flatstan.ListSerializer                builtins.list
 nevow.flat.flatstan.StringCastSerializer          builtins.dict

--- a/nevow/__init__.py
+++ b/nevow/__init__.py
@@ -142,6 +142,7 @@ nevow.query.QuerySlot       nevow.stan.slot               nevow.inevow.IQ
 nevow.query.QuerySlot       nevow.stan._PrecompiledSlot   nevow.inevow.IQ
 nevow.query.QueryNeverFind  nevow.stan.xml                nevow.inevow.IQ
 nevow.query.QueryNeverFind  nevow.stan.raw                nevow.inevow.IQ
+nevow.query.QueryNeverFind  builtins.bytes                nevow.inevow.IQ
 nevow.query.QueryNeverFind  nevow.stan.directive          nevow.inevow.IQ
 
 # I18N

--- a/nevow/__init__.py
+++ b/nevow/__init__.py
@@ -18,11 +18,11 @@ from nevow import flat
 from nevow.util import _namedAnyWithBuiltinTranslation
 
 # Python2.2 has a stupidity where instance methods have name
-# '__builtin__.instance method' instead of '__builtin__.instancemethod'
+# 'builtins.instance method' instead of 'builtins.instancemethod'
 # Workaround this error.
 def clean(o):
-    if o == '__builtins__.instancemethod' and sys.version_info < (2,3):
-        return '__builtins__.instance method'
+    if o == 'builtins.instancemethod' and sys.version_info < (2,3):
+        return 'builtins.instance method'
     return o
 
 
@@ -51,13 +51,13 @@ namespace = "http://nevow.com/ns/nevow/0.1"
 basic_adapters = """
 formless.annotate.Group                   formless.annotate.MetaTypedInterface        formless.iformless.ITyped
 
-nevow.accessors.DictionaryContainer    __builtins__.dict                         nevow.inevow.IContainer
-nevow.accessors.ListContainer          __builtins__.list                         nevow.inevow.IContainer
-nevow.accessors.ListContainer          __builtins__.tuple                        nevow.inevow.IContainer
+nevow.accessors.DictionaryContainer    builtins.dict                         nevow.inevow.IContainer
+nevow.accessors.ListContainer          builtins.list                         nevow.inevow.IContainer
+nevow.accessors.ListContainer          builtins.tuple                        nevow.inevow.IContainer
 
-nevow.accessors.FunctionAccessor       __builtin__.function                     nevow.inevow.IGettable
-nevow.accessors.FunctionAccessor       __builtin__.method                       nevow.inevow.IGettable
-nevow.accessors.FunctionAccessor       __builtin__.instancemethod               nevow.inevow.IGettable
+nevow.accessors.FunctionAccessor       builtins.function                     nevow.inevow.IGettable
+nevow.accessors.FunctionAccessor       builtins.method                       nevow.inevow.IGettable
+nevow.accessors.FunctionAccessor       builtins.instancemethod               nevow.inevow.IGettable
 nevow.accessors.DirectiveAccessor      nevow.stan.directive                     nevow.inevow.IGettable
 nevow.accessors.SlotAccessor           nevow.stan.slot                          nevow.inevow.IGettable
 nevow.accessors.SlotAccessor           nevow.stan._PrecompiledSlot              nevow.inevow.IGettable
@@ -109,7 +109,7 @@ formless.webform.FormErrors       nevow.guard.GuardSession                 forml
 formless.webform.FormErrors       nevow.testutil.FakeSession               formless.iformless.IFormErrors
 
 nevow.appserver.OldResourceAdapter                  twisted.web.resource.IResource      nevow.inevow.IResource
-nevow.static.staticHTML                 __builtins__.str                          nevow.inevow.IResource
+nevow.static.staticHTML                 builtins.str                          nevow.inevow.IResource
 
 nevow.appserver.sessionFactory  nevow.context.RequestContext    nevow.inevow.ISession
 nevow.rend.handFactory   nevow.context.RequestContext    nevow.inevow.IHand
@@ -134,7 +134,7 @@ nevow.util.currentSegmentsFactory  nevow.context.RequestContext   nevow.inevow.I
 
 nevow.query.QueryContext    nevow.context.WovenContext    nevow.inevow.IQ
 nevow.query.QueryLoader     nevow.inevow.IDocFactory      nevow.inevow.IQ
-nevow.query.QueryList       __builtin__.list              nevow.inevow.IQ
+nevow.query.QueryList       builtins.list              nevow.inevow.IQ
 nevow.query.QuerySlot       nevow.stan.slot               nevow.inevow.IQ
 nevow.query.QuerySlot       nevow.stan._PrecompiledSlot   nevow.inevow.IQ
 nevow.query.QueryNeverFind  nevow.stan.xml                nevow.inevow.IQ
@@ -162,20 +162,20 @@ nevow.flat.flatstan.EntitySerializer                 nevow.stan.Entity
 nevow.flat.flatstan.CommentSerializer             nevow.stan.Comment
 nevow.flat.flatstan.XmlSerializer                 nevow.stan.xml
 nevow.flat.flatstan.RawSerializer                 nevow.stan.raw
-nevow.flat.flatstan.StringSerializer              __builtins__.str
-nevow.flat.flatstan.StringSerializer              __builtins__.bytes
-nevow.flat.flatstan.NoneWarningSerializer         __builtins__.NoneType
-nevow.flat.flatstan.StringCastSerializer          __builtins__.int
-nevow.flat.flatstan.StringCastSerializer          __builtins__.float
-nevow.flat.flatstan.StringCastSerializer          __builtins__.long
-nevow.flat.flatstan.BooleanSerializer          __builtins__.bool
-nevow.flat.flatstan.ListSerializer                __builtins__.list
-nevow.flat.flatstan.StringCastSerializer          __builtins__.dict
-nevow.flat.flatstan.ListSerializer                __builtins__.tuple
-nevow.flat.flatstan.ListSerializer                __builtin__.generator
-nevow.flat.flatstan.FunctionSerializer            __builtin__.function
-nevow.flat.flatstan.FunctionSerializer            __builtins__.type
-nevow.flat.flatstan.MethodSerializer              __builtin__.instancemethod
+nevow.flat.flatstan.StringSerializer              builtins.str
+nevow.flat.flatstan.StringSerializer              builtins.bytes
+nevow.flat.flatstan.NoneWarningSerializer         builtins.NoneType
+nevow.flat.flatstan.StringCastSerializer          builtins.int
+nevow.flat.flatstan.StringCastSerializer          builtins.float
+nevow.flat.flatstan.StringCastSerializer          builtins.long
+nevow.flat.flatstan.BooleanSerializer          builtins.bool
+nevow.flat.flatstan.ListSerializer                builtins.list
+nevow.flat.flatstan.StringCastSerializer          builtins.dict
+nevow.flat.flatstan.ListSerializer                builtins.tuple
+nevow.flat.flatstan.ListSerializer                builtins.generator
+nevow.flat.flatstan.FunctionSerializer            builtins.function
+nevow.flat.flatstan.FunctionSerializer            builtins.type
+nevow.flat.flatstan.MethodSerializer              builtins.instancemethod
 nevow.flat.flatstan.RendererSerializer            nevow.inevow.IRenderer
 nevow.flat.flatstan.DirectiveSerializer           nevow.stan.directive
 nevow.flat.flatstan.SlotSerializer                nevow.stan.slot

--- a/nevow/__init__.py
+++ b/nevow/__init__.py
@@ -21,8 +21,8 @@ from nevow.util import _namedAnyWithBuiltinTranslation
 # '__builtin__.instance method' instead of '__builtin__.instancemethod'
 # Workaround this error.
 def clean(o):
-    if o == '__builtin__.instancemethod' and sys.version_info < (2,3):
-        return '__builtin__.instance method'
+    if o == '__builtins__.instancemethod' and sys.version_info < (2,3):
+        return '__builtins__.instance method'
     return o
 
 
@@ -51,9 +51,9 @@ namespace = "http://nevow.com/ns/nevow/0.1"
 basic_adapters = """
 formless.annotate.Group                   formless.annotate.MetaTypedInterface        formless.iformless.ITyped
 
-nevow.accessors.DictionaryContainer    __builtin__.dict                         nevow.inevow.IContainer
-nevow.accessors.ListContainer          __builtin__.list                         nevow.inevow.IContainer
-nevow.accessors.ListContainer          __builtin__.tuple                        nevow.inevow.IContainer
+nevow.accessors.DictionaryContainer    __builtins__.dict                         nevow.inevow.IContainer
+nevow.accessors.ListContainer          __builtins__.list                         nevow.inevow.IContainer
+nevow.accessors.ListContainer          __builtins__.tuple                        nevow.inevow.IContainer
 
 nevow.accessors.FunctionAccessor       __builtin__.function                     nevow.inevow.IGettable
 nevow.accessors.FunctionAccessor       __builtin__.method                       nevow.inevow.IGettable
@@ -109,7 +109,7 @@ formless.webform.FormErrors       nevow.guard.GuardSession                 forml
 formless.webform.FormErrors       nevow.testutil.FakeSession               formless.iformless.IFormErrors
 
 nevow.appserver.OldResourceAdapter                  twisted.web.resource.IResource      nevow.inevow.IResource
-nevow.static.staticHTML                 __builtin__.str                          nevow.inevow.IResource
+nevow.static.staticHTML                 __builtins__.str                          nevow.inevow.IResource
 
 nevow.appserver.sessionFactory  nevow.context.RequestContext    nevow.inevow.ISession
 nevow.rend.handFactory   nevow.context.RequestContext    nevow.inevow.IHand
@@ -162,19 +162,19 @@ nevow.flat.flatstan.EntitySerializer                 nevow.stan.Entity
 nevow.flat.flatstan.CommentSerializer             nevow.stan.Comment
 nevow.flat.flatstan.XmlSerializer                 nevow.stan.xml
 nevow.flat.flatstan.RawSerializer                 nevow.stan.raw
-nevow.flat.flatstan.StringSerializer              __builtin__.str
-nevow.flat.flatstan.StringSerializer              __builtin__.unicode
-nevow.flat.flatstan.NoneWarningSerializer         __builtin__.NoneType
-nevow.flat.flatstan.StringCastSerializer          __builtin__.int
-nevow.flat.flatstan.StringCastSerializer          __builtin__.float
-nevow.flat.flatstan.StringCastSerializer          __builtin__.long
-nevow.flat.flatstan.BooleanSerializer          __builtin__.bool
-nevow.flat.flatstan.ListSerializer                __builtin__.list
-nevow.flat.flatstan.StringCastSerializer          __builtin__.dict
-nevow.flat.flatstan.ListSerializer                __builtin__.tuple
+nevow.flat.flatstan.StringSerializer              __builtins__.str
+nevow.flat.flatstan.StringSerializer              __builtins__.bytes
+nevow.flat.flatstan.NoneWarningSerializer         __builtins__.NoneType
+nevow.flat.flatstan.StringCastSerializer          __builtins__.int
+nevow.flat.flatstan.StringCastSerializer          __builtins__.float
+nevow.flat.flatstan.StringCastSerializer          __builtins__.long
+nevow.flat.flatstan.BooleanSerializer          __builtins__.bool
+nevow.flat.flatstan.ListSerializer                __builtins__.list
+nevow.flat.flatstan.StringCastSerializer          __builtins__.dict
+nevow.flat.flatstan.ListSerializer                __builtins__.tuple
 nevow.flat.flatstan.ListSerializer                __builtin__.generator
 nevow.flat.flatstan.FunctionSerializer            __builtin__.function
-nevow.flat.flatstan.FunctionSerializer            __builtin__.type
+nevow.flat.flatstan.FunctionSerializer            __builtins__.type
 nevow.flat.flatstan.MethodSerializer              __builtin__.instancemethod
 nevow.flat.flatstan.RendererSerializer            nevow.inevow.IRenderer
 nevow.flat.flatstan.DirectiveSerializer           nevow.stan.directive

--- a/nevow/__init__.py
+++ b/nevow/__init__.py
@@ -149,12 +149,6 @@ load(basic_adapters)
 
 
 flatteners = """
-nevow.flat.flatmdom.MicroDomDocumentSerializer          twisted.web.microdom.Document
-nevow.flat.flatmdom.MicroDomTextSerializer              twisted.web.microdom.Text
-nevow.flat.flatmdom.MicroDomCommentSerializer           twisted.web.microdom.Comment
-nevow.flat.flatmdom.MicroDomElementSerializer           twisted.web.microdom.Element
-nevow.flat.flatmdom.MicroDomEntityReferenceSerializer   twisted.web.microdom.EntityReference
-nevow.flat.flatmdom.MicroDomCDATASerializer   twisted.web.microdom.CDATASection
 
 nevow.flat.flatstan.ProtoSerializer               nevow.stan.Proto
 nevow.flat.flatstan.TagSerializer                 nevow.stan.Tag

--- a/nevow/__init__.py
+++ b/nevow/__init__.py
@@ -155,7 +155,7 @@ flatteners = """
 
 nevow.flat.flatstan.ProtoSerializer               nevow.stan.Proto
 nevow.flat.flatstan.TagSerializer                 nevow.stan.Tag
-nevow.flat.flatstan.EntitySerializer                 nevow.stan.Entity
+nevow.flat.flatstan.EntitySerializer              nevow.stan.Entity
 nevow.flat.flatstan.CommentSerializer             nevow.stan.Comment
 nevow.flat.flatstan.XmlSerializer                 nevow.stan.xml
 nevow.flat.flatstan.RawSerializer                 nevow.stan.raw
@@ -164,7 +164,7 @@ nevow.flat.flatstan.StringSerializer              builtins.bytes
 nevow.flat.flatstan.NoneWarningSerializer         types.NoneType
 nevow.flat.flatstan.StringCastSerializer          builtins.int
 nevow.flat.flatstan.StringCastSerializer          builtins.float
-nevow.flat.flatstan.BooleanSerializer          builtins.bool
+nevow.flat.flatstan.BooleanSerializer             builtins.bool
 nevow.flat.flatstan.ListSerializer                builtins.list
 nevow.flat.flatstan.StringCastSerializer          builtins.dict
 nevow.flat.flatstan.ListSerializer                builtins.tuple
@@ -191,11 +191,12 @@ nevow.flat.flatstan.ListSerializer  itertools.chain
 nevow.flat.flatstan.ListSerializer  itertools.count
 nevow.flat.flatstan.ListSerializer  itertools.cycle
 nevow.flat.flatstan.ListSerializer  itertools.dropwhile
-nevow.flat.flatstan.ListSerializer  itertools.ifilter
-nevow.flat.flatstan.ListSerializer  itertools.ifilterfalse
-nevow.flat.flatstan.ListSerializer  itertools.imap
-nevow.flat.flatstan.ListSerializer  itertools.islice
-nevow.flat.flatstan.ListSerializer  itertools.izip
+nevow.flat.flatstan.ListSerializer  builtins.filter
+nevow.flat.flatstan.ListSerializer  itertools.filterfalse
+nevow.flat.flatstan.ListSerializer  builtins.map
+nevow.flat.flatstan.ListSerializer  builtins.slice
+nevow.flat.flatstan.ListSerializer  builtins.zip
+nevow.flat.flatstan.ListSerializer  builtins.range
 nevow.flat.flatstan.ListSerializer  itertools.repeat
 nevow.flat.flatstan.ListSerializer  itertools.starmap
 nevow.flat.flatstan.ListSerializer  itertools.takewhile

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -31,6 +31,7 @@ from nevow.flat.flatstan import allowSingleton
 from nevow.flat import flattenFactory
 from nevow.flat.ten import getFlattener
 from nevow.tags import raw
+from nevow.util import unicode, toBytes
 
 
 class FlattenerError(Exception):

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -412,8 +412,6 @@ def flatten(request, root, inAttribute, inXML):
         try:
             # In Python 2.5, after an exception, a generator's gi_frame is
             # None.
-            if not hasattr(stack[-1], 'gi_frame'):
-                raise StopIteration();
             frame = stack[-1].gi_frame
             element = next(stack[-1])
         except StopIteration:

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -426,7 +426,7 @@ def flatten(request, root, inAttribute, inXML):
             roots.append(frame.f_locals['root'])
             raise FlattenerError(e, roots, extract_tb(exc_info()[2]))
         else:
-            if type(element) is str:
+            if type(element) is bytes:
                 yield element
             elif isinstance(element, Deferred):
                 def cbx(xxx_todo_changeme):

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -61,14 +61,14 @@ class FlattenerError(Exception):
         @return: A string representation of C{obj}.
         @rtype: L{str}
         """
-        if isinstance(obj, str):
+        if isinstance(obj, bytes):
             # It's somewhat unlikely that there will ever be a str in the roots
             # list.  However, something like a MemoryError during a str.replace
             # call (eg, replacing " with &quot;) could possibly cause this.
             # Likewise, UTF-8 encoding a unicode string to a byte string might
             # fail like this.
             if len(obj) > 40:
-                if isinstance(obj, str):
+                if isinstance(obj, bytes):
                     prefix = 1
                 else:
                     prefix = 2
@@ -237,18 +237,18 @@ def _flatten(request, root, slotData, renderFactory, inAttribute, inXML):
         root = root.tag
 
     if isinstance(root, raw):
-        root = str(root)
+        root = toBytes(root)
         if inAttribute:
-            root = root.replace('"', '&quot;')
+            root = root.replace(b'"', b'&quot;')
         yield root
     elif isinstance(root, Proto):
-        root = str(root)
+        root = toBytes(root)
         if root:
             if root in allowSingleton:
-                yield '<' + root + ' />'
+                yield b'<' + root + b' />'
             else:
-                yield '<' + root + '></' + root + '>'
-    elif isinstance(root, str):
+                yield b'<' + root + b'></' + root + '>'
+    elif isinstance(root, bytes):
         yield escapedData(root, inAttribute, inXML)
     elif isinstance(root, slot):
         slotValue = _getSlotValue(root.name, slotData)
@@ -467,7 +467,7 @@ def _flattensome(state, write, schedule, result):
         except:
             result.errback()
         else:
-            if type(element) is str:
+            if type(element) is bytes:
                 write(element)
                 continue
             else:

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -468,7 +468,7 @@ def _flattensome(state, write, schedule, result):
         except:
             result.errback()
         else:
-            if type(element) is bytes:
+            if isinstance(element, bytes):
                 write(element)
                 continue
             else:

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -409,6 +409,8 @@ def flatten(request, root, inAttribute, inXML):
     """
     stack = [_flatten(request, root, [], None, inAttribute, inXML)]
     while stack:
+        if isinstance(stack[-1], str):
+            yield stack.pop(-1)
         try:
             # In Python 2.5, after an exception, a generator's gi_frame is
             # None.
@@ -424,6 +426,8 @@ def flatten(request, root, inAttribute, inXML):
             roots.append(frame.f_locals['root'])
             raise FlattenerError(e, roots, extract_tb(exc_info()[2]))
         else:
+            if isinstance(element, str):
+                yield element.encode('utf-8')
             if isinstance(element, bytes):
                 yield element
             elif isinstance(element, Deferred):

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -409,7 +409,6 @@ def flatten(request, root, inAttribute, inXML):
     """
     stack = [_flatten(request, root, [], None, inAttribute, inXML)]
     while stack:
-        print(411,stack)
         try:
             # In Python 2.5, after an exception, a generator's gi_frame is
             # None.

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -425,7 +425,7 @@ def flatten(request, root, inAttribute, inXML):
             roots.append(frame.f_locals['root'])
             raise FlattenerError(e, roots, extract_tb(exc_info()[2]))
         else:
-            if type(element) is bytes:
+            if isinstance(element, bytes):
                 yield element
             elif isinstance(element, Deferred):
                 def cbx(xxx_todo_changeme):

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -149,12 +149,12 @@ def escapedData(data, inAttribute, inXML):
     @return: The quoted form of C{data}.
     """
     if inXML or inAttribute:
-        data = data.replace('&', '&amp;'
-            ).replace('<', '&lt;'
-            ).replace('>', '&gt;')
+        data = toBytes(data).replace(b'&', b'&amp;'
+            ).replace(b'<', b'&lt;'
+            ).replace(b'>', b'&gt;')
     if inAttribute:
-        data = data.replace('"', '&quot;')
-    return data
+        data = toBytes(data).replace(b'"', b'&quot;')
+    return toBytes(data)
 
 
 

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -268,29 +268,29 @@ def _flatten(request, root, slotData, renderFactory, inAttribute, inXML):
                                             False, True):
                         yield element
                 else:
-                    yield '<'
+                    yield b'<'
                     if isinstance(root.tagName, str):
                         tagName = root.tagName.encode('ascii')
                     else:
-                        tagName = str(root.tagName)
+                        tagName = toBytes(root.tagName)
                     yield tagName
                     for k, v in sorted(root.attributes.items()):
                         if isinstance(k, str):
                             k = k.encode('ascii')
-                        yield " " + k + "=\""
+                        yield b" " + k + b"=\""
                         for element in _flatten(request, v, slotData,
                                                 renderFactory, True, True):
                             yield element
-                        yield "\""
+                        yield b"\""
                     if root.children or tagName not in allowSingleton:
-                        yield '>'
+                        yield b'>'
                         for element in _flatten(request, root.children,
                                                 slotData, renderFactory,
                                                 False, True):
                             yield element
-                        yield '</' + tagName + '>'
+                        yield b'</' + tagName + b'>'
                     else:
-                        yield ' />'
+                        yield b' />'
             else:
                 if isinstance(root.render, directive):
                     rendererName = root.render.name

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -61,7 +61,7 @@ class FlattenerError(Exception):
         @return: A string representation of C{obj}.
         @rtype: L{str}
         """
-        if isinstance(obj, (str, unicode)):
+        if isinstance(obj, str):
             # It's somewhat unlikely that there will ever be a str in the roots
             # list.  However, something like a MemoryError during a str.replace
             # call (eg, replacing " with &quot;) could possibly cause this.
@@ -175,7 +175,7 @@ def _ctxForRequest(request, slotData, renderFactory, inAttribute):
     ctx.remember(request, IRequest)
     for slotGroup in slotData:
         if slotGroup is not None:
-            for k, v in slotGroup.items():
+            for k, v in list(slotGroup.items()):
                 ctx.fillSlots(k, v)
     if renderFactory is not None:
         ctx.remember(_OldRendererFactory(renderFactory), IRendererFactory)
@@ -224,7 +224,7 @@ def _flatten(request, root, slotData, renderFactory, inAttribute, inXML):
     @return: An iterator which yields C{str}, L{Deferred}, and more iterators
         of the same type.
     """
-    if isinstance(root, unicode):
+    if isinstance(root, str):
         root = root.encode('utf-8')
     elif isinstance(root, WovenContext):
         # WovenContext is supported via the getFlattener case, but that is a
@@ -269,13 +269,13 @@ def _flatten(request, root, slotData, renderFactory, inAttribute, inXML):
                         yield element
                 else:
                     yield '<'
-                    if isinstance(root.tagName, unicode):
+                    if isinstance(root.tagName, str):
                         tagName = root.tagName.encode('ascii')
                     else:
                         tagName = str(root.tagName)
                     yield tagName
-                    for k, v in sorted(root.attributes.iteritems()):
-                        if isinstance(k, unicode):
+                    for k, v in sorted(root.attributes.items()):
+                        if isinstance(k, str):
                             k = k.encode('ascii')
                         yield " " + k + "=\""
                         for element in _flatten(request, v, slotData,
@@ -313,7 +313,7 @@ def _flatten(request, root, slotData, renderFactory, inAttribute, inXML):
         yield root.num
         yield ';'
     elif isinstance(root, xml):
-        if isinstance(root.content, unicode):
+        if isinstance(root.content, str):
             yield root.content.encode('utf-8')
         else:
             yield root.content
@@ -412,10 +412,10 @@ def flatten(request, root, inAttribute, inXML):
             # In Python 2.5, after an exception, a generator's gi_frame is
             # None.
             frame = stack[-1].gi_frame
-            element = stack[-1].next()
+            element = next(stack[-1])
         except StopIteration:
             stack.pop()
-        except Exception, e:
+        except Exception as e:
             stack.pop()
             roots = []
             for generator in stack:
@@ -426,7 +426,8 @@ def flatten(request, root, inAttribute, inXML):
             if type(element) is str:
                 yield element
             elif isinstance(element, Deferred):
-                def cbx((original, toFlatten)):
+                def cbx(xxx_todo_changeme):
+                    (original, toFlatten) = xxx_todo_changeme
                     stack.append(toFlatten)
                     return original
                 yield element.addCallback(cbx)
@@ -459,7 +460,7 @@ def _flattensome(state, write, schedule, result):
     """
     while True:
         try:
-            element = state.next()
+            element = next(state)
         except StopIteration:
             result.callback(None)
         except:

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -344,10 +344,10 @@ def _flatten(request, root, slotData, renderFactory, inAttribute, inXML):
                                            lambda ign: None)
                 def cbFlattened(result):
                     synchronous.append(None)
-                    return (result, (str(s) for s in results))
+                    return (result, (toBytes(s) for s in results))
                 flattened.addCallback(cbFlattened)
                 if synchronous:
-                    yield ''.join(map(str, results))
+                    yield b''.join(map(toBytes, results))
                 else:
                     yield flattened
             else:
@@ -409,8 +409,6 @@ def flatten(request, root, inAttribute, inXML):
     """
     stack = [_flatten(request, root, [], None, inAttribute, inXML)]
     while stack:
-        if isinstance(stack[-1], str):
-            yield stack.pop(-1)
         try:
             # In Python 2.5, after an exception, a generator's gi_frame is
             # None.
@@ -428,7 +426,7 @@ def flatten(request, root, inAttribute, inXML):
         else:
             if isinstance(element, str):
                 yield element.encode('utf-8')
-            if isinstance(element, bytes):
+            elif isinstance(element, bytes):
                 yield element
             elif isinstance(element, Deferred):
                 def cbx(xxx_todo_changeme):

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -408,6 +408,7 @@ def flatten(request, root, inAttribute, inXML):
     """
     stack = [_flatten(request, root, [], None, inAttribute, inXML)]
     while stack:
+        print(411,stack)
         try:
             # In Python 2.5, after an exception, a generator's gi_frame is
             # None.

--- a/nevow/_flat.py
+++ b/nevow/_flat.py
@@ -412,6 +412,8 @@ def flatten(request, root, inAttribute, inXML):
         try:
             # In Python 2.5, after an exception, a generator's gi_frame is
             # None.
+            if not hasattr(stack[-1], 'gi_frame'):
+                raise StopIteration();
             frame = stack[-1].gi_frame
             element = next(stack[-1])
         except StopIteration:

--- a/nevow/_version.py
+++ b/nevow/_version.py
@@ -33,19 +33,19 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
             if e.errno == errno.ENOENT:
                 continue
             if verbose:
-                print("unable to run %s" % args[0])
+                print(("unable to run %s" % args[0]))
                 print(e)
             return None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(("unable to find command, tried %s" % (commands,)))
         return None
     stdout = p.communicate()[0].strip()
     if sys.version >= '3':
         stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % args[0])
+            print(("unable to run %s (error)" % args[0]))
         return None
     return stdout
 
@@ -97,15 +97,15 @@ def versions_from_expanded_variables(variables, tag_prefix, verbose=False):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs-tags))
+            print(("discarding '%s', no digits" % ",".join(refs-tags)))
     if verbose:
-        print("likely tags: %s" % ",".join(sorted(tags)))
+        print(("likely tags: %s" % ",".join(sorted(tags))))
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
             if verbose:
-                print("picking %s" % r)
+                print(("picking %s" % r))
             return { "version": r,
                      "full": variables["full"].strip() }
     # no suitable tags, so we use the full revision id
@@ -122,7 +122,7 @@ def versions_from_vcs(tag_prefix, root, verbose=False):
 
     if not os.path.exists(os.path.join(root, ".git")):
         if verbose:
-            print("no .git in %s" % root)
+            print(("no .git in %s" % root))
         return {}
 
     GITS = ["git"]
@@ -134,7 +134,7 @@ def versions_from_vcs(tag_prefix, root, verbose=False):
         return {}
     if not stdout.startswith(tag_prefix):
         if verbose:
-            print("tag '%s' doesn't start with prefix '%s'" % (stdout, tag_prefix))
+            print(("tag '%s' doesn't start with prefix '%s'" % (stdout, tag_prefix)))
         return {}
     tag = stdout[len(tag_prefix):]
     stdout = run_command(GITS, ["rev-parse", "HEAD"], cwd=root)
@@ -152,8 +152,8 @@ def versions_from_parentdir(parentdir_prefix, root, verbose=False):
     dirname = os.path.basename(root)
     if not dirname.startswith(parentdir_prefix):
         if verbose:
-            print("guessing rootdir is '%s', but '%s' doesn't start with prefix '%s'" %
-                  (root, dirname, parentdir_prefix))
+            print(("guessing rootdir is '%s', but '%s' doesn't start with prefix '%s'" %
+                  (root, dirname, parentdir_prefix)))
         return None
     return {"version": dirname[len(parentdir_prefix):], "full": ""}
 

--- a/nevow/accessors.py
+++ b/nevow/accessors.py
@@ -48,7 +48,7 @@ class DirectiveAccessor(tpc.Adapter):
         data = context.locate(IData)
         container = IContainer(data, None)
         if container is None:
-            raise NoAccessor, "%r does not implement IContainer, and there is no registered adapter." % data
+            raise NoAccessor("%r does not implement IContainer, and there is no registered adapter." % data)
         child = container.child(context, self.original.name)
         return child
 

--- a/nevow/accessors.py
+++ b/nevow/accessors.py
@@ -12,7 +12,7 @@ and sequence (tuple, list) types as well as call any functions and
 methods found in the stan tree.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 import twisted.python.components as tpc
 
@@ -40,9 +40,8 @@ def convertToData(data, context):
 class NoAccessor(NotImplementedError):
     pass
 
-
+@implementer(IGettable)
 class DirectiveAccessor(tpc.Adapter):
-    implements(IGettable)
 
     def get(self, context):
         data = context.locate(IData)
@@ -52,27 +51,24 @@ class DirectiveAccessor(tpc.Adapter):
         child = container.child(context, self.original.name)
         return child
 
-
+@implementer(IGettable)
 class SlotAccessor(tpc.Adapter):
-    implements(IGettable)
 
     def get(self, context):
         return context.locateSlotData(self.original.name)
 
-
+@implementer(IGettable)
 class FunctionAccessor(tpc.Adapter):
-    implements(IGettable)
     def get(self, context):
         return self.original(context, context.locate(IData))
 
-
+@implementer(IGettable)
 class DictionaryContainer(tpc.Adapter):
-    implements(IContainer)
     
     def child(self, context, name):
         return self.original[name]
 
-
+@implementer(IContainer)
 class ObjectContainer(tpc.Adapter):
     """Retrieve object attributes in response to a data directive; providing
     easy access to your application objects' attributes.
@@ -104,7 +100,6 @@ class ObjectContainer(tpc.Adapter):
         </div>
     """
     
-    implements(IContainer)
     
     def child(self, context, name):
         if name[:1] == '_':
@@ -118,9 +113,8 @@ def intOrNone(s):
     except ValueError:
         return None
 
-
+@implementer(IContainer)
 class ListContainer(tpc.Adapter):
-    implements(IContainer)
 
     def child(self, context, name):
         if ':' in name:

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -9,7 +9,7 @@ A web application server built using twisted.web
 import cgi
 import warnings
 from collections import MutableMapping
-from urllib import unquote
+from urllib.parse import unquote
 
 from zope.interface import implements, classImplements
 
@@ -94,7 +94,7 @@ class _DictHeaders(MutableMapping):
         Return a C{dict} mapping each header name to the last corresponding
         header value.
         """
-        return dict(self.items())
+        return dict(list(self.items()))
 
 
     def has_key(self, key):
@@ -234,7 +234,7 @@ class NevowRequest(tpc.Componentized, server.Request):
 
         # Resource Identification
         self.prepath = []
-        self.postpath = map(unquote, self.path[1:].split('/'))
+        self.postpath = list(map(unquote, self.path[1:].split('/')))
         self.sitepath = []
 
         self.deferred = defer.Deferred()
@@ -444,7 +444,7 @@ class NevowSite(server.Site):
             assert  len(newpath) < len(path), "Infinite loop impending..."
 
         ## We found a Resource... update the request.prepath and postpath
-        for x in xrange(len(path) - len(newpath)):
+        for x in range(len(path) - len(newpath)):
             if request.postpath:
                 request.prepath.append(request.postpath.pop(0))
 

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -291,6 +291,9 @@ class NevowRequest(server.Request, tpc.Componentized):
             # No response can be sent at this point.
             pass
         elif isinstance(html, str):
+            self.write(html.encode('utf-8'))
+            self.finishRequest(  True )
+        elif isinstance(html, bytes):
             self.write(html)
             self.finishRequest(  True )
         elif html is errorMarker:

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -127,11 +127,11 @@ class DefaultExceptionHandler:
         log.err(reason)
         request = inevow.IRequest(ctx)
         request.setResponseCode(http.INTERNAL_SERVER_ERROR)
-        request.write("<html><head><title>Exception</title></head><body>")
+        request.write(b"<html><head><title>Exception</title></head><body>")
         from nevow import failure
         result = failure.formatFailure(reason)
-        request.write(''.join(flat.flatten(result)))
-        request.write("</body></html>")
+        request.write(''.join(flat.flatten(result)).encode('utf-8'))
+        request.write(b"</body></html>")
 
         request.finishRequest( False )
 
@@ -161,8 +161,8 @@ def processingFailed(reason, request, ctx):
         log.err()
         log.err("Original exception:", isErr=1)
         log.err(reason)
-        request.write("<html><head><title>Internal Server Error</title></head>")
-        request.write("<body><h1>Internal Server Error</h1>An error occurred rendering the requested page. Additionally, an error occurred rendering the error page.</body></html>")
+        request.write(b"<html><head><title>Internal Server Error</title></head>")
+        request.write(b"<body><h1>Internal Server Error</h1>An error occurred rendering the requested page. Additionally, an error occurred rendering the error page.</body></html>")
         request.finishRequest( False )
 
     return errorMarker

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -232,8 +232,7 @@ class NevowRequest(server.Request, tpc.Componentized):
 
         # Resource Identification
         self.prepath = []
-        print(unquote,self.path,type(self.path))
-        self.postpath = list(map(unquote, self.path[1:].split('/')))
+        self.postpath = list(map(unquote, str(self.path[1:].split('/'), 'utf-8')))
         self.sitepath = []
 
         self.deferred = defer.Deferred()

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -11,7 +11,7 @@ import warnings
 from collections import MutableMapping
 from urllib.parse import unquote
 
-from zope.interface import implements, classImplements
+from zope.interface import implementer, classImplements
 
 import twisted.python.components as tpc
 from twisted.web import server
@@ -105,9 +105,8 @@ class _DictHeaders(MutableMapping):
         return key in self
 
 
-
+@implementer(inevow.ICanHandleException)
 class UninformativeExceptionHandler:
-    implements(inevow.ICanHandleException)
 
     def renderHTTP_exception(self, ctx, reason):
         request = inevow.IRequest(ctx)
@@ -121,9 +120,8 @@ class UninformativeExceptionHandler:
         log.err(reason)
         return """<div style="border: 1px dashed red; color: red; clear: both">[[ERROR]]</div>"""
 
-
+@implementer(inevow.ICanHandleException)
 class DefaultExceptionHandler:
-    implements(inevow.ICanHandleException)
 
     def renderHTTP_exception(self, ctx, reason):
         log.err(reason)
@@ -173,7 +171,7 @@ def processingFailed(reason, request, ctx):
 def defaultExceptionHandlerFactory(ctx):
     return DefaultExceptionHandler()
 
-
+@implementer(inevow.IRequest)
 class NevowRequest(tpc.Componentized, server.Request):
     """
     A Request subclass which does additional
@@ -195,7 +193,7 @@ class NevowRequest(tpc.Componentized, server.Request):
         lost) or not.  C{False} until this happens, C{True} afterwards.
     @type _lostConnection: L{bool}
     """
-    implements(inevow.IRequest)
+    
 
     fields = None
     _lostConnection = False
@@ -475,9 +473,8 @@ class NevowSite(server.Site):
 
 
 ## This should be moved somewhere else, it's cluttering up this module.
-
+@implementer(inevow.IResource)
 class OldResourceAdapter(object):
-    implements(inevow.IResource)
 
     # This is required to properly handle the interaction between
     # original.isLeaf and request.postpath, from which PATH_INFO is set in

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -5,7 +5,7 @@
 """
 A web application server built using twisted.web
 """
-
+from nevow.utils import unicode, toBytes
 import cgi
 import warnings
 from collections import MutableMapping
@@ -130,7 +130,7 @@ class DefaultExceptionHandler:
         request.write(b"<html><head><title>Exception</title></head><body>")
         from nevow import failure
         result = failure.formatFailure(reason)
-        request.write(''.join(flat.flatten(result)).encode('utf-8'))
+        request.write(toBytes(''.join(flat.flatten(result))))
         request.write(b"</body></html>")
 
         request.finishRequest( False )
@@ -291,7 +291,7 @@ class NevowRequest(server.Request, tpc.Componentized):
             # No response can be sent at this point.
             pass
         elif isinstance(html, str):
-            self.write(html.encode('utf-8'))
+            self.write(toBytes(html))
             self.finishRequest(  True )
         elif isinstance(html, bytes):
             self.write(html)

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -130,7 +130,7 @@ class DefaultExceptionHandler:
         request.write(b"<html><head><title>Exception</title></head><body>")
         from nevow import failure
         result = failure.formatFailure(reason)
-        request.write(toBytes(b''.join((toBytes(i) for i in flat.flatten(result)))))
+        request.write(flat.flatten(result))
         request.write(b"</body></html>")
 
         request.finishRequest( False )

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -232,6 +232,7 @@ class NevowRequest(server.Request, tpc.Componentized):
 
         # Resource Identification
         self.prepath = []
+        print(unquote,self.path,type(self.path))
         self.postpath = list(map(unquote, self.path[1:].split('/')))
         self.sitepath = []
 

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -232,7 +232,7 @@ class NevowRequest(server.Request, tpc.Componentized):
 
         # Resource Identification
         self.prepath = []
-        self.postpath = list(map(unquote, str(self.path[1:].split('/'), 'utf-8')))
+        self.postpath = list(map(unquote, str(self.path[1:], 'utf-8').split('/')))
         self.sitepath = []
 
         self.deferred = defer.Deferred()

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -130,7 +130,7 @@ class DefaultExceptionHandler:
         request.write(b"<html><head><title>Exception</title></head><body>")
         from nevow import failure
         result = failure.formatFailure(reason)
-        request.write(toBytes(b''.join(flat.flatten(result))))
+        request.write(toBytes(b''.join((toBytes(i) for i in flat.flatten(result)))))
         request.write(b"</body></html>")
 
         request.finishRequest( False )

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -130,7 +130,7 @@ class DefaultExceptionHandler:
         request.write(b"<html><head><title>Exception</title></head><body>")
         from nevow import failure
         result = failure.formatFailure(reason)
-        request.write(toBytes(''.join(flat.flatten(result))))
+        request.write(toBytes(b''.join(flat.flatten(result))))
         request.write(b"</body></html>")
 
         request.finishRequest( False )

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -226,9 +226,9 @@ class NevowRequest(server.Request, tpc.Componentized):
         self.site = self.channel.site
 
         # set various default headers
-        self.setHeader('server', server.version)
-        self.setHeader('date', server.http.datetimeToString())
-        self.setHeader('content-type', "text/html; charset=UTF-8")
+        self.setHeader(b'server', server.version)
+        self.setHeader(b'date', server.http.datetimeToString())
+        self.setHeader(b'content-type', "text/html; charset=UTF-8")
 
         # Resource Identification
         self.prepath = []

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -172,7 +172,7 @@ def defaultExceptionHandlerFactory(ctx):
     return DefaultExceptionHandler()
 
 @implementer(inevow.IRequest)
-class NevowRequest(tpc.Componentized, server.Request):
+class NevowRequest(server.Request, tpc.Componentized):
     """
     A Request subclass which does additional
     processing if a form was POSTed. When a form is POSTed,

--- a/nevow/appserver.py
+++ b/nevow/appserver.py
@@ -5,7 +5,7 @@
 """
 A web application server built using twisted.web
 """
-from nevow.utils import unicode, toBytes
+from nevow.util import unicode, toBytes
 import cgi
 import warnings
 from collections import MutableMapping

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1346,6 +1346,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def getJSModuleURL(self, moduleName):
+        print(1349, moduleName)
         return self.jsModuleRoot.child(moduleName)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1314,7 +1314,9 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
     def callRemote(self, methodName, *args):
         requestID = 's2c%i' % (self._requestIDCounter(),)
-        message = ('call', (bytes(methodName, 'ascii'), requestID, args))
+        if isinstance(methodName, bytes):
+            methodName=methodName.decode('utf-8')
+        message = ('call', (methodName, requestID, args))
         resultD = defer.Deferred()
         self._remoteCalls[requestID] = resultD
         self.addMessage(message)
@@ -1477,9 +1479,9 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                     result = (
                         'Divmod.Error',
                         ['%s: %s' % (
-                                result.type.__name__.decode('ascii'),
-                                result.getErrorMessage().decode('ascii'))])
-            message = ('respond', (unicode(requestId), success, result))
+                                result.type.__name__,
+                                result.getErrorMessage())])
+            message = ('respond', (str(requestId), success, result))
             self.addMessage(message)
         result.addBoth(_cbCall)
 
@@ -1794,7 +1796,7 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         return self.page.callRemote(
             "Nevow.Athena.callByAthenaID",
             self._athenaID,
-            str(methodName, 'ascii'),
+            methodName,
             varargs)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1241,7 +1241,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         if not self._supportedBrowser(request):
             request.write(self.renderUnsupported(ctx))
             return ''
-
+        print(1244,URL.fromString(flat.flatten(here, ctx)))
         self._becomeLive(URL.fromString(flat.flatten(here, ctx)))
 
         neverEverCache(request)

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -909,7 +909,8 @@ class _HasJSClass(object):
         the page before this Fragment's widget can be instantiated.  modules
         are accessible.
         """
-        print(912, self.page.getJSModuleURL(dep.name))
+        for i in self._getModuleForClass().allDependencies(memo):
+            print(913, self.page.getJSModuleURL(i.name))
         return [
             (dep.name, self.page.getJSModuleURL(dep.name))
             for dep

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1406,7 +1406,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         arguments to the named method.
         """
         return '%s(%s);' % (
-            methodName, ', '.join([json.serialize(arg) for arg in args]))
+            methodName, unicode(b', '.join([json.serialize(arg) for arg in args])))
 
 
     def child_jsmodule(self, ctx):

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1635,7 +1635,7 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         C{self.page}, add this object to the page and fill the I{athena:id}
         slot with this object's Athena identifier.
         """
-        assert isinstance(self.jsClass, bytes), "jsClass must be a unicode string"
+        assert isinstance(self.jsClass, str), "jsClass must be a unicode string"
 
         if self.page is None:
             raise OrphanedFragment(self)

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1376,7 +1376,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         bootstrapString = b'\n'.join(
             [self._bootstrapCall(method, args) for
              method, args in self._bootstraps(ctx)])
-        print(1379, [flatten(url)
+        print(1379, [flat.flatten(url)
              for (name, url)
              in self._getRequiredModules(self._jsDepsMemo)])
         return ctx.tag[

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1521,8 +1521,8 @@ def _rewriteEventHandlerToAttribute(tag):
                 name = info.attributes['event'].encode('ascii')
                 handler = info.attributes['handler']
                 extraAttributes[name] = _handlerFormat % {
-                    'handler': json.serialize(handler.decode('ascii')),
-                    'event': json.serialize(name.decode('ascii'))}
+                    'handler': json.serialize(unicode(handler, 'ascii')),
+                    'event': json.serialize(unicode(name, 'ascii'))}
                 tag(**extraAttributes)
     return tag
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1363,7 +1363,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def render_liveglue(self, ctx, data):
-        bootstrapString = '\n'.join(
+        bootstrapString = b'\n'.join(
             [self._bootstrapCall(method, args) for
              method, args in self._bootstraps(ctx)])
         return ctx.tag[

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1376,7 +1376,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         bootstrapString = b'\n'.join(
             [self._bootstrapCall(method, args) for
              method, args in self._bootstraps(ctx)])
-        print(1379, [self.getImportStan(jsDeps.getModuleForName(name).name)
+        print(1379, [name, url
              for (name, url)
              in self._getRequiredModules(self._jsDepsMemo)])
         return ctx.tag[

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -903,7 +903,7 @@ class _HasJSClass(object):
         Get a L{JSModule} object for the class specified by this object's
         jsClass string.
         """
-        print(906, jsDeps.getModuleForClass(self.jsClass))
+        print(906, self.page.getJSModuleURL(jsDeps.getModuleForClass(self.jsClass).name))
         return jsDeps.getModuleForClass(self.jsClass)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -177,7 +177,7 @@ class AthenaModule(object):
     def _extractImports(self, fileObj):
         s = fileObj.read()
         for m in self._importExpression.finditer(s):
-            yield self.getOrCreate(m.group(1).decode('ascii'), self.mapping)
+            yield self.getOrCreate(unicode(m.group(1), 'ascii'), self.mapping)
 
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -314,7 +314,7 @@ def _collectPackageBelow(baseDir, extension):
 
             name = stem + fn[:-(len(extension) + 1)]
             path = os.path.join(root, fn)
-            mapping[str(name, 'ascii')] = path
+            mapping[unicode(name, 'ascii')] = path
     return mapping
 
 
@@ -1314,7 +1314,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
     def callRemote(self, methodName, *args):
         requestID = 's2c%i' % (self._requestIDCounter(),)
-        message = ('call', (str(methodName, 'ascii'), requestID, args))
+        message = ('call', (bytes(methodName, 'ascii'), requestID, args))
         resultD = defer.Deferred()
         self._remoteCalls[requestID] = resultD
         self.addMessage(message)
@@ -1406,8 +1406,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         @param args: a list of objects that will be JSON-serialized as
         arguments to the named method.
         """
-        return '%s(%s);' % (
-            methodName, unicode(b', '.join([json.serialize(arg) for arg in args])))
+        return b'%s(%s);' % (
+            toBytes(methodName), (b', '.join([json.serialize(arg) for arg in args])))
 
 
     def child_jsmodule(self, ctx):
@@ -1474,7 +1474,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                         ['%s: %s' % (
                                 result.type.__name__.decode('ascii'),
                                 result.getErrorMessage().decode('ascii'))])
-            message = ('respond', (str(requestId), success, result))
+            message = ('respond', (unicode(requestId), success, result))
             self.addMessage(message)
         result.addBoth(_cbCall)
 
@@ -1631,14 +1631,14 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         C{self.page}, add this object to the page and fill the I{athena:id}
         slot with this object's Athena identifier.
         """
-        assert isinstance(self.jsClass, str), "jsClass must be a unicode string"
+        assert isinstance(self.jsClass, bytes), "jsClass must be a unicode string"
 
         if self.page is None:
             raise OrphanedFragment(self)
         self._athenaID = self.page.addLocalObject(self)
         if self.page._didConnect:
             self.connectionMade()
-        tag.fillSlots('athena:id', str(self._athenaID))
+        tag.fillSlots('athena:id', toBytes(self._athenaID))
 
 
     def setFragmentParent(self, fragmentParent):

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1346,7 +1346,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def getJSModuleURL(self, moduleName):
-        print(1349, moduleName)
+        print(1349, self.jsModuleRoot.child(moduleName), flat.flatten(self.jsModuleRoot.child(moduleName)))
         return self.jsModuleRoot.child(moduleName)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1346,6 +1346,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def getJSModuleURL(self, moduleName):
+        print(1349, self.jsModuleRoot)
+        print(1350, self.jsModuleRoot.child(''))
         return self.jsModuleRoot.child(moduleName)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1520,7 +1520,7 @@ def _rewriteEventHandlerToAttribute(tag):
                 info = tag.children.pop(i)
                 name = info.attributes['event'].encode('ascii')
                 handler = info.attributes['handler']
-                extraAttributes[name] = _handlerFormat % {
+                extraAttributes[unicode(name)] = _handlerFormat % {
                     'handler': json.serialize(unicode(handler, 'ascii')),
                     'event': json.serialize(unicode(name, 'ascii'))}
                 tag(**extraAttributes)

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1241,8 +1241,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         if not self._supportedBrowser(request):
             request.write(self.renderUnsupported(ctx))
             return ''
-        print(1244,here)
-        print(1244,URL.fromString(flat.flatten(here, ctx)))
         self._becomeLive(URL.fromString(flat.flatten(here, ctx)))
 
         neverEverCache(request)
@@ -1347,8 +1345,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def getJSModuleURL(self, moduleName):
-        print(1349, self.jsModuleRoot)
-        print(1350, self.jsModuleRoot.child(''))
         return self.jsModuleRoot.child(moduleName)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -909,6 +909,7 @@ class _HasJSClass(object):
         the page before this Fragment's widget can be instantiated.  modules
         are accessible.
         """
+        print(912, getJSModuleURL(dep.name))
         return [
             (dep.name, self.page.getJSModuleURL(dep.name))
             for dep

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -49,7 +49,7 @@ class LivePageError(Exception):
     """
     Base exception for LivePage errors.
     """
-    jsClass = u'Divmod.Error'
+    jsClass = 'Divmod.Error'
 
 
 
@@ -58,7 +58,7 @@ class NoSuchMethod(LivePageError):
     Raised when an attempt is made to invoke a method which is not defined or
     exposed.
     """
-    jsClass = u'Nevow.Athena.NoSuchMethod'
+    jsClass = 'Nevow.Athena.NoSuchMethod'
 
     def __init__(self, objectID, methodName):
         self.objectID = objectID
@@ -186,7 +186,7 @@ class AthenaModule(object):
         Calculate our dependencies given the path to our source.
         """
         depgen = self._extractImports(file(jsFile, 'rU'))
-        return self.packageDeps + dict.fromkeys(depgen).keys()
+        return self.packageDeps + list(dict.fromkeys(depgen).keys())
 
 
     def dependencies(self):
@@ -300,7 +300,7 @@ def _collectPackageBelow(baseDir, extension):
             path = os.path.join(root, dir, '__init__.' + extension)
             if not os.path.exists(path):
                 path = EMPTY
-            mapping[unicode(name, 'ascii')] = path
+            mapping[str(name, 'ascii')] = path
             _revMap[os.path.join(root, dir)] = name + '.'
 
         for fn in filenames:
@@ -315,7 +315,7 @@ def _collectPackageBelow(baseDir, extension):
 
             name = stem + fn[:-(len(extension) + 1)]
             path = os.path.join(root, fn)
-            mapping[unicode(name, 'ascii')] = path
+            mapping[str(name, 'ascii')] = path
     return mapping
 
 
@@ -540,11 +540,11 @@ def getJSFailure(exc, modules):
     """
     Convert a serialized client-side exception to a Failure.
     """
-    text = '%s: %s' % (exc[u'name'], exc[u'message'])
+    text = '%s: %s' % (exc['name'], exc['message'])
 
     frames = []
-    if u'stack' in exc:
-        frames = parseStack(exc[u'stack'])
+    if 'stack' in exc:
+        frames = parseStack(exc['stack'])
 
     return failure.Failure(JSException(text), exc_tb=buildTraceback(frames, modules))
 
@@ -618,8 +618,8 @@ class ConnectionLost(Exception):
     pass
 
 
-CLOSE = u'close'
-UNLOAD = u'unload'
+CLOSE = 'close'
+UNLOAD = 'unload'
 
 class ReliableMessageDelivery(object):
     """
@@ -775,8 +775,8 @@ class ReliableMessageDelivery(object):
 
 
     def _unregisterDeferredAsOutputChannel(self, deferred):
-        for i in xrange(len(self.outputs)):
-            if self.outputs[i][0].im_self is deferred:
+        for i in range(len(self.outputs)):
+            if self.outputs[i][0].__self__ is deferred:
                 output, timeout = self.outputs.pop(i)
                 timeout.cancel()
                 break
@@ -1007,7 +1007,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
     @ivar _localObjectIDCounter: A callable that will return a new
         locally-unique object ID each time it is called.
     """
-    jsClass = u'Nevow.Athena.PageWidget'
+    jsClass = 'Nevow.Athena.PageWidget'
     cssModule = None
 
     factory = LivePageFactory()
@@ -1140,7 +1140,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         if self.cssModuleRoot is None:
             self.cssModuleRoot = location.child(self.clientID).child('cssmodule')
 
-        self._requestIDCounter = itertools.count().next
+        self._requestIDCounter = itertools.count().__next__
 
         self._messageDeliverer = ReliableMessageDelivery(
             self,
@@ -1151,7 +1151,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
             connectionMade=self._connectionMade)
         self._remoteCalls = {}
         self._localObjects = {}
-        self._localObjectIDCounter = itertools.count().next
+        self._localObjectIDCounter = itertools.count().__next__
 
         self.addLocalObject(self)
 
@@ -1252,7 +1252,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         """
         Invoke connectionMade on all attached widgets.
         """
-        for widget in self._localObjects.values():
+        for widget in list(self._localObjects.values()):
             widget.connectionMade()
         self._didConnect = True
 
@@ -1274,10 +1274,10 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                 d.errback(reason)
             calls = self._remoteCalls
             self._remoteCalls = {}
-            for (reqID, resD) in calls.iteritems():
+            for (reqID, resD) in calls.items():
                 resD.errback(reason)
             if self._didConnect:
-                for widget in self._localObjects.values():
+                for widget in list(self._localObjects.values()):
                     widget.connectionLost(reason)
             self.factory.removeClient(self.clientID)
 
@@ -1316,8 +1316,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def callRemote(self, methodName, *args):
-        requestID = u's2c%i' % (self._requestIDCounter(),)
-        message = (u'call', (unicode(methodName, 'ascii'), requestID, args))
+        requestID = 's2c%i' % (self._requestIDCounter(),)
+        message = ('call', (str(methodName, 'ascii'), requestID, args))
         resultD = defer.Deferred()
         self._remoteCalls[requestID] = resultD
         self.addMessage(message)
@@ -1439,12 +1439,13 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         raise AttributeError(methodName)
 
 
-    def liveTransportMessageReceived(self, ctx, (action, args)):
+    def liveTransportMessageReceived(self, ctx, xxx_todo_changeme):
         """
         A message was received from the reliable transport layer.  Process it by
         dispatching it first to myself, then later to application code if
         applicable.
         """
+        (action, args) = xxx_todo_changeme
         method = getattr(self, 'action_' + action)
         method(ctx, *args)
 
@@ -1472,11 +1473,11 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                         result.value.args)
                 else:
                     result = (
-                        u'Divmod.Error',
-                        [u'%s: %s' % (
+                        'Divmod.Error',
+                        ['%s: %s' % (
                                 result.type.__name__.decode('ascii'),
                                 result.getErrorMessage().decode('ascii'))])
-            message = (u'respond', (unicode(requestId), success, result))
+            message = ('respond', (str(requestId), success, result))
             self.addMessage(message)
         result.addBoth(_cbCall)
 
@@ -1517,7 +1518,7 @@ def _rewriteEventHandlerToAttribute(tag):
     """
     if isinstance(tag, stan.Tag):
         extraAttributes = {}
-        for i in xrange(len(tag.children) - 1, -1, -1):
+        for i in range(len(tag.children) - 1, -1, -1):
             if isinstance(tag.children[i], stan.Tag) and tag.children[i].tagName == 'athena:handler':
                 info = tag.children.pop(i)
                 name = info.attributes['event'].encode('ascii')
@@ -1565,7 +1566,7 @@ def _rewriteAthenaId(tag):
             if headers is not None:
                 ids = headers.split()
                 headers = [_mangleId(headerId) for headerId in ids]
-                for n in xrange(len(headers) - 1, 0, -1):
+                for n in range(len(headers) - 1, 0, -1):
                     headers.insert(n, ' ')
                 tag.attributes['headers'] = headers
     return tag
@@ -1580,7 +1581,7 @@ def rewriteAthenaIds(root):
 
 
 class _LiveMixin(_HasJSClass, _HasCSSModule):
-    jsClass = u'Nevow.Athena.Widget'
+    jsClass = 'Nevow.Athena.Widget'
     cssModule = None
 
     preprocessors = [rewriteEventHandlerNodes, rewriteAthenaIds]
@@ -1633,7 +1634,7 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         C{self.page}, add this object to the page and fill the I{athena:id}
         slot with this object's Athena identifier.
         """
-        assert isinstance(self.jsClass, unicode), "jsClass must be a unicode string"
+        assert isinstance(self.jsClass, str), "jsClass must be a unicode string"
 
         if self.page is None:
             raise OrphanedFragment(self)
@@ -1710,15 +1711,15 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         del children[0]
 
         self._structuredCache = {
-            u'requiredModules': [(name, flat.flatten(url).decode('utf-8'))
+            'requiredModules': [(name, flat.flatten(url).decode('utf-8'))
                                  for (name, url) in requiredModules],
-            u'requiredCSSModules': [flat.flatten(url).decode('utf-8')
+            'requiredCSSModules': [flat.flatten(url).decode('utf-8')
                                     for url in requiredCSSModules],
-            u'class': self.jsClass,
-            u'id': self._athenaID,
-            u'initArguments': tuple(self.getInitialArguments()),
-            u'markup': markup,
-            u'children': children}
+            'class': self.jsClass,
+            'id': self._athenaID,
+            'initArguments': tuple(self.getInitialArguments()),
+            'markup': markup,
+            'children': children}
         return self._structuredCache
 
 
@@ -1738,9 +1739,9 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         # This will only be set if _structured() is being run.
         if context.get('children') is not None:
             context.get('children').append({
-                    u'class': self.jsClass,
-                    u'id': self._athenaID,
-                    u'initArguments': self.getInitialArguments()})
+                    'class': self.jsClass,
+                    'id': self._athenaID,
+                    'initArguments': self.getInitialArguments()})
             context.get('requiredModules').extend(requiredModules)
             context.get('requiredCSSModules').extend(requiredCSSModules)
             return tag
@@ -1789,7 +1790,7 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         return self.page.callRemote(
             "Nevow.Athena.callByAthenaID",
             self._athenaID,
-            unicode(methodName, 'ascii'),
+            str(methodName, 'ascii'),
             varargs)
 
 
@@ -1995,7 +1996,7 @@ class IntrospectionFragment(LiveFragment):
     the state of a live page.
     """
 
-    jsClass = u'Nevow.Athena.IntrospectionWidget'
+    jsClass = 'Nevow.Athena.IntrospectionWidget'
 
     docFactory = loaders.stan(
         tags.span(render=tags.directive('liveFragment'))[

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -395,9 +395,12 @@ class JSDependencies(object):
             self._loadPlugins = False
 
         jsMod = className
+        
         while jsMod:
+            print(398, jsMod)
             try:
                 self.mapping[jsMod]
+                print(403, self.mapping[jsMod])
             except KeyError:
                 if '.' not in jsMod:
                     break

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1530,8 +1530,8 @@ def _rewriteEventHandlerToAttribute(tag):
                 name = info.attributes['event'].encode('ascii')
                 handler = info.attributes['handler']
                 extraAttributes[unicode(name)] = _handlerFormat % {
-                    'handler': json.serialize(unicode(handler, 'ascii')),
-                    'event': json.serialize(unicode(name, 'ascii'))}
+                    b'handler': json.serialize(bytes(handler, 'ascii')),
+                    b'event': json.serialize(bytes(name, 'ascii'))}
                 tag(**extraAttributes)
     return tag
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1376,6 +1376,9 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         bootstrapString = b'\n'.join(
             [self._bootstrapCall(method, args) for
              method, args in self._bootstraps(ctx)])
+        print(1379, [self.getImportStan(jsDeps.getModuleForName(name).name)
+             for (name, url)
+             in self._getRequiredModules(self._jsDepsMemo)])
         return ctx.tag[
             self.getStylesheetStan(self._getRequiredCSSModules(self._cssDepsMemo)),
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -401,7 +401,6 @@ class JSDependencies(object):
             try:
                 self.mapping[jsMod]
                 print(403, self.mapping[jsMod])
-                print(404, JSModule.getOrCreate(jsMod, self.mapping))
             except KeyError:
                 if '.' not in jsMod:
                     break
@@ -903,7 +902,6 @@ class _HasJSClass(object):
         Get a L{JSModule} object for the class specified by this object's
         jsClass string.
         """
-        print(906, self.page.getJSModuleURL(jsDeps.getModuleForClass(self.jsClass).name))
         return jsDeps.getModuleForClass(self.jsClass)
 
 
@@ -1242,6 +1240,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         if not self._supportedBrowser(request):
             request.write(self.renderUnsupported(ctx))
             return ''
+
         self._becomeLive(URL.fromString(flat.flatten(here, ctx)))
 
         neverEverCache(request)
@@ -1346,7 +1345,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def getJSModuleURL(self, moduleName):
-        print(1349, moduleName, self.jsModuleRoot.child(moduleName), flat.flatten(self.jsModuleRoot.child(moduleName)))
         return self.jsModuleRoot.child(moduleName)
 
 
@@ -1370,16 +1368,13 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         t[r]
         
         return [t,
-                tags.script(type='text/javascript', src=flat.flatten(self.getJSModuleURL(moduleName)))]
+                tags.script(type='text/javascript', src=self.getJSModuleURL(moduleName))]
 
 
     def render_liveglue(self, ctx, data):
         bootstrapString = b'\n'.join(
             [self._bootstrapCall(method, args) for
              method, args in self._bootstraps(ctx)])
-        print(1379, [flat.flatten(url)
-             for (name, url)
-             in self._getRequiredModules(self._jsDepsMemo)])
         return ctx.tag[
             self.getStylesheetStan(self._getRequiredCSSModules(self._cssDepsMemo)),
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1370,7 +1370,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         t[r]
         
         return [t,
-                tags.script(type='text/javascript', src=self.getJSModuleURL(moduleName))]
+                tags.script(type='text/javascript', src=flat.flatten(self.getJSModuleURL(moduleName)))]
 
 
     def render_liveglue(self, ctx, data):

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1376,7 +1376,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         bootstrapString = b'\n'.join(
             [self._bootstrapCall(method, args) for
              method, args in self._bootstraps(ctx)])
-        print(1379, [name, url
+        print(1379, [(name, url)
              for (name, url)
              in self._getRequiredModules(self._jsDepsMemo)])
         return ctx.tag[

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1346,7 +1346,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
     def getJSModuleURL(self, moduleName):
-        print(1349, self.jsModuleRoot.child(moduleName), flat.flatten(self.jsModuleRoot.child(moduleName)))
+        print(1349, moduleName, self.jsModuleRoot.child(moduleName), flat.flatten(self.jsModuleRoot.child(moduleName)))
         return self.jsModuleRoot.child(moduleName)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -89,14 +89,14 @@ def activeChannel(request):
 class MappingResource(object):
     """
     L{inevow.IResource} which looks up segments in a mapping between symbolic
-    names and the files they correspond to. 
+    names and the files they correspond to.
 
     @type mapping: C{dict}
     @ivar mapping: A map between symbolic, requestable names (eg,
     'Nevow.Athena') and C{str} instances which name files containing data
     which should be served in response.
     """
-    
+
 
     def __init__(self, mapping):
         self.mapping = mapping
@@ -395,7 +395,7 @@ class JSDependencies(object):
             self._loadPlugins = False
 
         jsMod = className
-        
+
         while jsMod:
             try:
                 self.mapping[jsMod]
@@ -1360,11 +1360,11 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
     def getImportStan(self, moduleName):
         moduleDef = jsModuleDeclaration(moduleName);
-        
+
         t=tags.script(type='text/javascript')
         r=tags.raw(toBytes(moduleDef))
         t[r]
-        
+
         return [t,
                 tags.script(type='text/javascript', src=flat.flatten(self.getJSModuleURL(moduleName)))]
 
@@ -1530,7 +1530,7 @@ def _rewriteEventHandlerToAttribute(tag):
                 kw={
                     b'handler': json.serialize(unicode(handler, 'ascii')),
                     b'event': json.serialize(unicode(name, 'ascii'))}
-                
+
                 extraAttributes[unicode(name)] = _handlerFormat % kw
                 tag(**extraAttributes)
     return tag
@@ -1688,7 +1688,7 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         # different module from whence nevow.athena and nevow.testutil could
         # import it. -exarkun
         from nevow.testutil import FakeRequest
-        return "".join(_flat.flatten(FakeRequest(), what, False, False))
+        return b"".join((toBytes(i) for i in _flat.flatten(FakeRequest(), what, False, False)))
 
 
     def _structured(self):

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -397,10 +397,8 @@ class JSDependencies(object):
         jsMod = className
         
         while jsMod:
-            print(398, jsMod)
             try:
                 self.mapping[jsMod]
-                print(403, self.mapping[jsMod])
             except KeyError:
                 if '.' not in jsMod:
                     break
@@ -912,8 +910,6 @@ class _HasJSClass(object):
         the page before this Fragment's widget can be instantiated.  modules
         are accessible.
         """
-        for i in self._getModuleForClass().allDependencies(memo):
-            print(913, self.page.getJSModuleURL(i.name))
         return [
             (dep.name, self.page.getJSModuleURL(dep.name))
             for dep
@@ -1532,7 +1528,6 @@ def _rewriteEventHandlerToAttribute(tag):
                 kw={
                     b'handler': json.serialize(unicode(handler, 'ascii')),
                     b'event': json.serialize(unicode(name, 'ascii'))}
-                print(1535,kw)
                 
                 extraAttributes[unicode(name)] = _handlerFormat % kw
                 tag(**extraAttributes)

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1021,7 +1021,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
     # proxies) then deferreds returned from notifyOnDisconnect() will be
     # errbacked with ConnectionLost, and the LivePage will be removed from the
     # factory's cache, and then likely garbage collected.
-    TRANSPORTLESS_DISCONNECT_TIMEOUT = 30
+    TRANSPORTLESS_DISCONNECT_TIMEOUT = 300
 
     # This is the amount of time that each 'transport' request will remain open
     # to the server.  Although the underlying transport, i.e. the conceptual

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -903,6 +903,7 @@ class _HasJSClass(object):
         Get a L{JSModule} object for the class specified by this object's
         jsClass string.
         """
+        print(906, jsDeps.getModuleForClass(self.jsClass))
         return jsDeps.getModuleForClass(self.jsClass)
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1390,9 +1390,9 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         """
         return [
             ("Divmod.bootstrap",
-             [flat.flatten(self.transportRoot, ctx).decode("ascii")]),
+             [flat.flatten(self.transportRoot, ctx)]),
             ("Nevow.Athena.bootstrap",
-             [self.jsClass, self.clientID.decode('ascii')])]
+             [self.jsClass, self.clientID])]
 
 
     def _bootstrapCall(self, methodName, args):

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -909,7 +909,7 @@ class _HasJSClass(object):
         the page before this Fragment's widget can be instantiated.  modules
         are accessible.
         """
-        print(912, getJSModuleURL(dep.name))
+        print(912, self.page.getJSModuleURL(dep.name))
         return [
             (dep.name, self.page.getJSModuleURL(dep.name))
             for dep

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1241,6 +1241,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         if not self._supportedBrowser(request):
             request.write(self.renderUnsupported(ctx))
             return ''
+        print(1244,here)
         print(1244,URL.fromString(flat.flatten(here, ctx)))
         self._becomeLive(URL.fromString(flat.flatten(here, ctx)))
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -2,7 +2,7 @@
 
 import itertools, os, re, warnings
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import defer, error, reactor
 from twisted.python import log, failure, context
@@ -85,7 +85,7 @@ def activeChannel(request):
     request.write('')
 
 
-
+@implementer(inevow.IResource)
 class MappingResource(object):
     """
     L{inevow.IResource} which looks up segments in a mapping between symbolic
@@ -96,7 +96,7 @@ class MappingResource(object):
     'Nevow.Athena') and C{str} instances which name files containing data
     which should be served in response.
     """
-    implements(inevow.IResource)
+    
 
     def __init__(self, mapping):
         self.mapping = mapping
@@ -251,7 +251,7 @@ class CSSModule(AthenaModule):
     _modules = {}
 
 
-
+@implementer(plugin.IPlugin, inevow.IJavascriptPackage)
 class JSPackage(object):
     """
     A Javascript package.
@@ -260,7 +260,6 @@ class JSPackage(object):
     @ivar mapping: Mapping between JS module names and C{str} representing
     filesystem paths containing their implementations.
     """
-    implements(plugin.IPlugin, inevow.IJavascriptPackage)
 
     def __init__(self, mapping):
         self.mapping = mapping
@@ -319,7 +318,7 @@ def _collectPackageBelow(baseDir, extension):
     return mapping
 
 
-
+@implementer(plugin.IPlugin, inevow.IJavascriptPackage)
 class AutoJSPackage(object):
     """
     A L{inevow.IJavascriptPackage} implementation that scans an on-disk
@@ -329,19 +328,17 @@ class AutoJSPackage(object):
     @ivar baseDir: A path to the root of a JavaScript packages/modules
     filesystem hierarchy.
     """
-    implements(plugin.IPlugin, inevow.IJavascriptPackage)
 
     def __init__(self, baseDir):
         self.mapping = _collectPackageBelow(baseDir, 'js')
 
 
-
+@implementer(plugin.IPlugin, inevow.ICSSPackage)
 class AutoCSSPackage(object):
     """
     Like L{AutoJSPackage}, but for CSS packages.  Modules within this package
     can be referenced by L{LivePage.cssModule} or L{LiveElement.cssModule}.
     """
-    implements(plugin.IPlugin, inevow.ICSSPackage)
 
     def __init__(self, baseDir):
         self.mapping = _collectPackageBelow(baseDir, 'css')
@@ -549,9 +546,8 @@ def getJSFailure(exc, modules):
     return failure.Failure(JSException(text), exc_tb=buildTraceback(frames, modules))
 
 
-
+@implementer(inevow.IResource)
 class LivePageTransport(object):
-    implements(inevow.IResource)
 
     def __init__(self, messageDeliverer, useActiveChannels=True):
         self.messageDeliverer = messageDeliverer

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1513,7 +1513,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
 handler = stan.Proto('athena:handler')
-_handlerFormat = b"return Nevow.Athena.Widget.handleEvent(this, %(event)s, %(handler)s);"
+_handlerFormat = b"return Nevow.Athena.Widget.handleEvent(this, %(event)s, %(handler)s, event);"
 
 def _rewriteEventHandlerToAttribute(tag):
     """

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -72,8 +72,8 @@ def neverEverCache(request):
     Set headers to indicate that the response to this request should never,
     ever be cached.
     """
-    request.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
-    request.setHeader('Pragma', 'no-cache')
+    request.setHeader(b'Cache-Control', 'no-store, no-cache, must-revalidate')
+    request.setHeader(b'Pragma', 'no-cache')
 
 
 def activeChannel(request):
@@ -81,7 +81,7 @@ def activeChannel(request):
     Mark this connection as a 'live' channel by setting the Connection: close
     header and flushing all headers immediately.
     """
-    request.setHeader("Connection", "close")
+    request.setHeader(b"Connection", "close")
     request.write('')
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -401,6 +401,7 @@ class JSDependencies(object):
             try:
                 self.mapping[jsMod]
                 print(403, self.mapping[jsMod])
+                print(404, JSModule.getOrCreate(jsMod, self.mapping))
             except KeyError:
                 if '.' not in jsMod:
                     break

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1376,7 +1376,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         bootstrapString = b'\n'.join(
             [self._bootstrapCall(method, args) for
              method, args in self._bootstraps(ctx)])
-        print(1379, [(name, url)
+        print(1379, [flatten(url)
              for (name, url)
              in self._getRequiredModules(self._jsDepsMemo)])
         return ctx.tag[

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -395,7 +395,6 @@ class JSDependencies(object):
             self._loadPlugins = False
 
         jsMod = className
-        print(398, jsMod, self.mapping)
         while jsMod:
             try:
                 self.mapping[jsMod]

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -12,7 +12,7 @@ from twisted import plugin
 from nevow import inevow, plugins, flat, _flat
 from nevow import rend, loaders, static
 from nevow import json, util, tags, guard, stan
-from nevow.util import CachedFile
+from nevow.util import CachedFile, unicode, toBytes
 from nevow.useragent import UserAgent, browsers
 from nevow.url import here, URL
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1357,7 +1357,12 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
     def getImportStan(self, moduleName):
         moduleDef = jsModuleDeclaration(moduleName);
-        return [tags.script(type='text/javascript')[tags.raw(moduleDef)],
+        
+        t=tags.script(type='text/javascript')
+        r=tags.raw(moduleDef)
+        t[r]
+        
+        return [t,
                 tags.script(type='text/javascript', src=self.getJSModuleURL(moduleName))]
 
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1368,7 +1368,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         t[r]
         
         return [t,
-                tags.script(type='text/javascript', src=self.getJSModuleURL(moduleName))]
+                tags.script(type='text/javascript', src=flat.flatten(self.getJSModuleURL(moduleName)))]
 
 
     def render_liveglue(self, ctx, data):

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -36,7 +36,6 @@ expose = util.Expose(
     """)
 
 
-
 class OrphanedFragment(Exception):
     """
     Raised when an operation requiring a parent is attempted on an unattached
@@ -44,13 +43,11 @@ class OrphanedFragment(Exception):
     """
 
 
-
 class LivePageError(Exception):
     """
     Base exception for LivePage errors.
     """
     jsClass = 'Divmod.Error'
-
 
 
 class NoSuchMethod(LivePageError):
@@ -64,7 +61,6 @@ class NoSuchMethod(LivePageError):
         self.objectID = objectID
         self.methodName = methodName
         LivePageError.__init__(self, objectID, methodName)
-
 
 
 def neverEverCache(request):
@@ -97,14 +93,11 @@ class MappingResource(object):
     which should be served in response.
     """
 
-
     def __init__(self, mapping):
         self.mapping = mapping
 
-
     def renderHTTP(self, ctx):
         return rend.FourOhFour()
-
 
     def resourceFactory(self, fileName):
         """
@@ -113,7 +106,6 @@ class MappingResource(object):
         """
         return static.File(fileName)
 
-
     def locateChild(self, ctx, segments):
         try:
             impl = self.mapping[segments[0]]
@@ -121,7 +113,6 @@ class MappingResource(object):
             return rend.NotFound
         else:
             return self.resourceFactory(impl), []
-
 
 
 def _dependencyOrdered(coll, memo):
@@ -133,7 +124,6 @@ def _dependencyOrdered(coll, memo):
     @param memo: A dictionary mapping module names to their dependencies that
                  will be used as a mutable cache.
     """
-
 
 
 class AthenaModule(object):
@@ -155,8 +145,8 @@ class AthenaModule(object):
             return cls._modules[name]
         mod = cls._modules[name] = cls(name, mapping)
         return mod
-    getOrCreate = classmethod(getOrCreate)
 
+    getOrCreate = classmethod(getOrCreate)
 
     def __init__(self, name, mapping):
         self.name = name
@@ -168,18 +158,15 @@ class AthenaModule(object):
 
         self._cache = CachedFile(self.mapping[self.name], self._getDeps)
 
-
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, self.name,)
 
-
     _importExpression = re.compile('^// import (.+)$', re.MULTILINE)
+
     def _extractImports(self, fileObj):
         s = fileObj.read()
         for m in self._importExpression.finditer(s):
             yield self.getOrCreate(unicode(m.group(1), 'ascii'), self.mapping)
-
-
 
     def _getDeps(self, jsFile):
         """
@@ -188,13 +175,11 @@ class AthenaModule(object):
         depgen = self._extractImports(open(jsFile, 'rU', encoding=getEncoding(jsFile)))
         return self.packageDeps + list(dict.fromkeys(depgen).keys())
 
-
     def dependencies(self):
         """
         Return a list of names of other JavaScript modules we depend on.
         """
         return self._cache.load()
-
 
     def allDependencies(self, memo=None):
         """
@@ -235,13 +220,11 @@ class AthenaModule(object):
         return ordered
 
 
-
 class JSModule(AthenaModule):
     """
     L{AthenaModule} subclass for dealing with Javascript modules.
     """
-    _modules= {}
-
+    _modules = {}
 
 
 class CSSModule(AthenaModule):
@@ -263,7 +246,6 @@ class JSPackage(object):
 
     def __init__(self, mapping):
         self.mapping = mapping
-
 
 
 def _collectPackageBelow(baseDir, extension):
@@ -344,7 +326,6 @@ class AutoCSSPackage(object):
         self.mapping = _collectPackageBelow(baseDir, 'css')
 
 
-
 def allJavascriptPackages():
     """
     Return a dictionary mapping JavaScript module names to local filenames
@@ -358,7 +339,6 @@ def allJavascriptPackages():
     return d
 
 
-
 def allCSSPackages():
     """
     Like L{allJavascriptPackages}, but for CSS packages.
@@ -367,7 +347,6 @@ def allCSSPackages():
     for p in plugin.getPlugIns(inevow.ICSSPackage, plugins):
         d.update(p.mapping)
     return d
-
 
 
 class JSDependencies(object):
@@ -384,7 +363,6 @@ class JSDependencies(object):
             self._loadPlugins = True
         else:
             self.mapping = mapping
-
 
     def getModuleForName(self, className):
         """
@@ -406,17 +384,18 @@ class JSDependencies(object):
             else:
                 return JSModule.getOrCreate(jsMod, self.mapping)
         raise RuntimeError("Unknown class: %r" % (className,))
+
     getModuleForClass = getModuleForName
 
 
 jsDeps = JSDependencies()
 
 
-
 class CSSRegistry(object):
     """
     Keeps track of a set of CSS modules.
     """
+
     def __init__(self, mapping=None):
         if mapping is None:
             mapping = {}
@@ -425,7 +404,6 @@ class CSSRegistry(object):
             loadPlugins = False
         self.mapping = mapping
         self._loadPlugins = loadPlugins
-
 
     def getModuleForName(self, moduleName):
         """
@@ -444,8 +422,8 @@ class CSSRegistry(object):
             raise RuntimeError('Unknown CSS module: %r' % (moduleName,))
         return CSSModule.getOrCreate(moduleName, self.mapping)
 
-_theCSSRegistry = CSSRegistry()
 
+_theCSSRegistry = CSSRegistry()
 
 
 class JSException(Exception):
@@ -454,21 +432,21 @@ class JSException(Exception):
     """
 
 
-
 class JSCode(object):
     """
     Class for mock code objects in mock JS frames.
     """
+
     def __init__(self, name, filename):
         self.co_name = name
         self.co_filename = filename
-
 
 
 class JSFrame(object):
     """
     Class for mock frame objects in JS client-side traceback wrappers.
     """
+
     def __init__(self, func, fname, ln):
         self.f_back = None
         self.f_locals = {}
@@ -477,17 +455,16 @@ class JSFrame(object):
         self.f_lineno = ln
 
 
-
 class JSTraceback(object):
     """
     Class for mock traceback objects representing client-side JavaScript
     tracebacks.
     """
+
     def __init__(self, frame, ln):
         self.tb_frame = frame
         self.tb_lineno = ln
         self.tb_next = None
-
 
 
 def parseStack(stack):
@@ -513,7 +490,6 @@ def parseStack(stack):
     return frames
 
 
-
 def buildTraceback(frames, modules):
     """
     Build a chain of mock traceback objects from a serialized Error (or other
@@ -533,7 +509,6 @@ def buildTraceback(frames, modules):
     return first
 
 
-
 def getJSFailure(exc, modules):
     """
     Convert a serialized client-side exception to a Failure.
@@ -549,15 +524,12 @@ def getJSFailure(exc, modules):
 
 @implementer(inevow.IResource)
 class LivePageTransport(object):
-
     def __init__(self, messageDeliverer, useActiveChannels=True):
         self.messageDeliverer = messageDeliverer
         self.useActiveChannels = useActiveChannels
 
-
     def locateChild(self, ctx, segments):
         return rend.NotFound
-
 
     def renderHTTP(self, ctx):
         req = inevow.IRequest(ctx)
@@ -572,7 +544,6 @@ class LivePageTransport(object):
         response.addCallback(json.serialize)
         req.notifyFinish().addErrback(lambda err: self.messageDeliverer._unregisterDeferredAsOutputChannel(response))
         return response
-
 
 
 class LivePageFactory:
@@ -618,6 +589,7 @@ class ConnectionLost(Exception):
 CLOSE = 'close'
 UNLOAD = 'unload'
 
+
 class ReliableMessageDelivery(object):
     """
     A reliable message delivery abstraction over a possibly unreliable transport.
@@ -653,11 +625,12 @@ class ReliableMessageDelivery(object):
     _stopped = False
     _connected = False
 
-    outgoingAck = -1            # sequence number which has been acknowledged
-                                # by this end of the connection.
+    outgoingAck = -1  # sequence number which has been acknowledged
+    # by this end of the connection.
 
-    outgoingSeq = -1            # sequence number of the next message to be
-                                # added to the outgoing queue.
+    outgoingSeq = -1  # sequence number of the next message to be
+
+    # added to the outgoing queue.
 
     def __init__(self,
                  livePage,
@@ -678,16 +651,13 @@ class ReliableMessageDelivery(object):
         self.connectionMade = connectionMade
         self.connectionLost = connectionLost
 
-
     def _connectTimedOut(self):
         self._transportlessTimeoutCall = None
         self.connectionLost(failure.Failure(ConnectFailed("Timeout")))
 
-
     def _transportlessTimedOut(self):
         self._transportlessTimeoutCall = None
         self.connectionLost(failure.Failure(ConnectionLost("Timeout")))
-
 
     def _idleTimedOut(self):
         output, timeout = self.outputs.pop(0)
@@ -695,15 +665,12 @@ class ReliableMessageDelivery(object):
             self._transportlessTimeoutCall = self.scheduler(self.transportlessTimeout, self._transportlessTimedOut)
         output([self.outgoingAck, []])
 
-
     def _sendMessagesToOutput(self, output):
         log.msg(athena_send_messages=True, count=len(self.messages))
         output([self.outgoingAck, self.messages])
 
-
     def pause(self):
         self._paused += 1
-
 
     def _trySendMessages(self):
         """
@@ -717,7 +684,6 @@ class ReliableMessageDelivery(object):
                 self._transportlessTimeoutCall = self.scheduler(self.transportlessTimeout, self._transportlessTimedOut)
             self._sendMessagesToOutput(output)
 
-
     def unpause(self):
         """
         Decrement the pause counter and if the resulting state is not still
@@ -727,7 +693,6 @@ class ReliableMessageDelivery(object):
         if self._paused == 0:
             self._trySendMessages()
             self._flushOutputs()
-
 
     def addMessage(self, msg):
         if self._stopped:
@@ -742,7 +707,6 @@ class ReliableMessageDelivery(object):
                 self._transportlessTimeoutCall = self.scheduler(self.transportlessTimeout, self._transportlessTimedOut)
             self._sendMessagesToOutput(output)
 
-
     def addOutput(self, output):
         if self._transportlessTimeoutCall is not None:
             self._transportlessTimeoutCall.cancel()
@@ -755,7 +719,6 @@ class ReliableMessageDelivery(object):
                 self._sendMessagesToOutput(output)
             else:
                 self.outputs.append((output, self.scheduler(self.idleTimeout, self._idleTimedOut)))
-
 
     def close(self):
         assert not self._stopped, "Cannot multiply stop ReliableMessageDelivery"
@@ -770,7 +733,6 @@ class ReliableMessageDelivery(object):
             self._transportlessTimeoutCall.cancel()
             self._transportlessTimeoutCall = None
 
-
     def _unregisterDeferredAsOutputChannel(self, deferred):
         for i in range(len(self.outputs)):
             if self.outputs[i][0].__self__ is deferred:
@@ -781,7 +743,6 @@ class ReliableMessageDelivery(object):
             return
         if not self.outputs:
             self._transportlessTimeoutCall = self.scheduler(self.transportlessTimeout, self._transportlessTimedOut)
-
 
     def _createOutputDeferred(self):
         """
@@ -795,7 +756,6 @@ class ReliableMessageDelivery(object):
             self._trySendMessages()
             self._flushOutputs()
         return d
-
 
     def _flushOutputs(self):
         """
@@ -813,7 +773,6 @@ class ReliableMessageDelivery(object):
             output, timeout = self.outputs.pop(0)
             timeout.cancel()
             output([self.outgoingAck, []])
-
 
     def basketCaseReceived(self, ctx, basketCase):
         """
@@ -885,6 +844,7 @@ BOOTSTRAP_NODE_ID = 'athena:bootstrap'
 BOOTSTRAP_STATEMENT = ("eval(document.getElementById('" + BOOTSTRAP_NODE_ID +
                        "').getAttribute('payload'));")
 
+
 class _HasJSClass(object):
     """
     A utility to share some code between the L{LivePage}, L{LiveElement}, and
@@ -902,7 +862,6 @@ class _HasJSClass(object):
         """
         return jsDeps.getModuleForClass(self.jsClass)
 
-
     def _getRequiredModules(self, memo):
         """
         Return a list of two-tuples containing module names and URLs at which
@@ -917,7 +876,6 @@ class _HasJSClass(object):
             if self.page._shouldInclude(dep.name)]
 
 
-
 def jsModuleDeclaration(name):
     """
     Generate Javascript for a module declaration.
@@ -928,7 +886,6 @@ def jsModuleDeclaration(name):
     return '%s%s = {"__name__": "%s"};' % (var, name, name)
 
 
-
 class _HasCSSModule(object):
     """
     C{cssModule}-handling code common to L{LivePage}, L{LiveElement} and
@@ -937,6 +894,7 @@ class _HasCSSModule(object):
     @ivar cssModule: A CSS module name.
     @type cssModule: C{unicode} or C{NoneType}
     """
+
     def _getRequiredCSSModules(self, memo):
         """
         Return a list of CSS module URLs.
@@ -951,7 +909,6 @@ class _HasCSSModule(object):
             for dep in module.allDependencies(memo)
             if self.page._shouldIncludeCSSModule(dep.name)]
 
-
     def getStylesheetStan(self, modules):
         """
         Get some stan which will include the given modules.
@@ -964,7 +921,6 @@ class _HasCSSModule(object):
             tags.link(
                 rel='stylesheet', type='text/css', href=url)
             for url in modules]
-
 
 
 class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
@@ -1048,7 +1004,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
             tags.body[
                 'Your browser is not supported by the Athena toolkit.']])
 
-
     def __init__(self, iface=None, rootObject=None, jsModules=None,
                  jsModuleRoot=None, transportRoot=None, cssModules=None,
                  cssModuleRoot=None, *a, **kw):
@@ -1074,13 +1029,11 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         self._jsDepsMemo = {}
         self._cssDepsMemo = {}
 
-
     def _shouldInclude(self, moduleName):
         if moduleName not in self._includedModules:
             self._includedModules.append(moduleName)
             return True
         return False
-
 
     def _shouldIncludeCSSModule(self, moduleName):
         """
@@ -1095,7 +1048,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
             return True
         return False
 
-
     # Child lookup may be dependent on the application state
     # represented by a LivePage.  In this case, it is preferable to
     # dispatch child lookup on the same LivePage instance as performed
@@ -1109,10 +1061,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         else:
             return client, segments[1:]
 
-
     def child___athena_private__(self, ctx):
         return _thePrivateAthenaResource
-
 
     # A note on timeout/disconnect logic: whenever a live client goes from some
     # transports to no transports, a timer starts; whenever it goes from no
@@ -1152,7 +1102,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
         self.addLocalObject(self)
 
-
     def _supportedBrowser(self, request):
         """
         Determine whether a known-unsupported browser is making a request.
@@ -1175,7 +1124,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
             return agent.version >= requiredVersion
         return True
 
-
     def renderUnsupported(self, ctx):
         """
         Render a notification to the user that his user agent is
@@ -1186,7 +1134,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         @return: Something renderable (same behavior as L{renderHTTP})
         """
         return flat.flatten(self.unsupportedBrowserLoader.load())
-
 
     def renderHTTP(self, ctx):
         """
@@ -1244,7 +1191,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
             return json.serialize(self.clientID.decode("ascii"))
         return rend.Page.renderHTTP(self, ctx)
 
-
     def _connectionMade(self):
         """
         Invoke connectionMade on all attached widgets.
@@ -1252,7 +1198,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         for widget in list(self._localObjects.values()):
             widget.connectionMade()
         self._didConnect = True
-
 
     def _disconnected(self, reason):
         """
@@ -1278,12 +1223,10 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                     widget.connectionLost(reason)
             self.factory.removeClient(self.clientID)
 
-
     def connectionMade(self):
         """
         Callback invoked when the transport is first connected.
         """
-
 
     def connectionLost(self, reason):
         """
@@ -1294,12 +1237,10 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         Override this.
         """
 
-
     def addLocalObject(self, obj):
         objID = self._localObjectIDCounter()
         self._localObjects[objID] = obj
         return objID
-
 
     def removeLocalObject(self, objID):
         """
@@ -1311,21 +1252,18 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         """
         del self._localObjects[objID]
 
-
     def callRemote(self, methodName, *args):
         requestID = 's2c%i' % (self._requestIDCounter(),)
         if isinstance(methodName, bytes):
-            methodName=methodName.decode('utf-8')
+            methodName = methodName.decode('utf-8')
         message = ('call', (methodName, requestID, args))
         resultD = defer.Deferred()
         self._remoteCalls[requestID] = resultD
         self.addMessage(message)
         return resultD
 
-
     def addMessage(self, message):
         self._messageDeliverer.addMessage(message)
-
 
     def notifyOnDisconnect(self):
         """
@@ -1341,10 +1279,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         self._disconnectNotifications.append(d)
         return d
 
-
     def getJSModuleURL(self, moduleName):
         return self.jsModuleRoot.child(moduleName)
-
 
     def getCSSModuleURL(self, moduleName):
         """
@@ -1357,17 +1293,15 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         """
         return self.cssModuleRoot.child(moduleName)
 
-
     def getImportStan(self, moduleName):
         moduleDef = jsModuleDeclaration(moduleName);
 
-        t=tags.script(type='text/javascript')
-        r=tags.raw(toBytes(moduleDef))
+        t = tags.script(type='text/javascript')
+        r = tags.raw(toBytes(moduleDef))
         t[r]
 
         return [t,
                 tags.script(type='text/javascript', src=flat.flatten(self.getJSModuleURL(moduleName)))]
-
 
     def render_liveglue(self, ctx, data):
         bootstrapString = b'\n'.join(
@@ -1387,7 +1321,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                 BOOTSTRAP_STATEMENT]
         ]
 
-
     def _bootstraps(self, ctx):
         """
         Generate a list of 2-tuples of (methodName, arguments) representing the
@@ -1402,7 +1335,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
             ("Nevow.Athena.bootstrap",
              [self.jsClass, self.clientID])]
 
-
     def _bootstrapCall(self, methodName, args):
         """
         Generate a string to call a 'bootstrap' function in an Athena JavaScript
@@ -1416,10 +1348,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         return b'%s(%s);' % (
             toBytes(methodName), (b', '.join([json.serialize(arg) for arg in args])))
 
-
     def child_jsmodule(self, ctx):
         return MappingResource(self.jsModules.mapping)
-
 
     def child_cssmodule(self, ctx):
         """
@@ -1427,8 +1357,8 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         """
         return MappingResource(self.cssModules.mapping)
 
-
     _transportResource = None
+
     def child_transport(self, ctx):
         if self._transportResource is None:
             self._transportResource = LivePageTransport(
@@ -1436,12 +1366,10 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                 self.useActiveChannels)
         return self._transportResource
 
-
     def locateMethod(self, ctx, methodName):
         if methodName in self.iface:
             return getattr(self.rootObject, methodName)
         raise AttributeError(methodName)
-
 
     def liveTransportMessageReceived(self, ctx, xxx_todo_changeme):
         """
@@ -1452,7 +1380,6 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         (action, args) = xxx_todo_changeme
         method = getattr(self, 'action_' + action)
         method(ctx, *args)
-
 
     def action_call(self, ctx, requestId, method, objectID, args, kwargs):
         """
@@ -1465,6 +1392,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
             result = defer.fail(NoSuchMethod(objectID, method))
         else:
             result = defer.maybeDeferred(func, *args, **kwargs)
+
         def _cbCall(result):
             success = True
             if isinstance(result, failure.Failure):
@@ -1479,12 +1407,12 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
                     result = (
                         'Divmod.Error',
                         ['%s: %s' % (
-                                result.type.__name__,
-                                result.getErrorMessage())])
+                            result.type.__name__,
+                            result.getErrorMessage())])
             message = ('respond', (str(requestId), success, result))
             self.addMessage(message)
-        result.addBoth(_cbCall)
 
+        result.addBoth(_cbCall)
 
     def action_respond(self, ctx, responseId, success, result):
         """
@@ -1496,12 +1424,10 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         else:
             callDeferred.errback(getJSFailure(result, self.jsModules.mapping))
 
-
     def action_noop(self, ctx):
         """
         Handle noop, used to initialise and ping the live transport.
         """
-
 
     def action_close(self, ctx):
         """
@@ -1511,9 +1437,9 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         self._disconnected(error.ConnectionDone("Connection closed"))
 
 
-
 handler = stan.Proto('athena:handler')
 _handlerFormat = b"return Nevow.Athena.Widget.handleEvent(this, %(event)s, %(handler)s, event);"
+
 
 def _rewriteEventHandlerToAttribute(tag):
     """
@@ -1527,7 +1453,7 @@ def _rewriteEventHandlerToAttribute(tag):
                 info = tag.children.pop(i)
                 name = info.attributes['event'].encode('ascii')
                 handler = info.attributes['handler']
-                kw={
+                kw = {
                     b'handler': json.serialize(unicode(handler, 'ascii')),
                     b'event': json.serialize(unicode(name, 'ascii'))}
 
@@ -1610,15 +1536,17 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
                 if self.fragmentParent is not None:
                     self._page = self.fragmentParent.page
             return self._page
+
         def set(self, value):
             self._page = value
+
         doc = """
         The L{LivePage} instance which is the topmost container of this
         fragment.
         """
         return get, set, None, doc
-    page = property(*page())
 
+    page = property(*page())
 
     def getInitialArguments(self):
         """
@@ -1632,7 +1560,6 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         @rtype: C{list} or C{tuple}
         """
         return ()
-
 
     def _prepare(self, tag):
         """
@@ -1648,7 +1575,6 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         if self.page._didConnect:
             self.connectionMade()
         tag.fillSlots('athena:id', toBytes(self._athenaID))
-
 
     def setFragmentParent(self, fragmentParent):
         """
@@ -1676,7 +1602,6 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         self.page = fragmentParent.page
         fragmentParent.liveFragmentChildren.append(self)
 
-
     def _flatten(self, what):
         """
         Synchronously flatten C{what} and return the result as a C{str}.
@@ -1689,7 +1614,6 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         # import it. -exarkun
         from nevow.testutil import FakeRequest
         return b"".join((toBytes(i) for i in _flat.flatten(FakeRequest(), what, False, False)))
-
 
     def _structured(self):
         """
@@ -1714,20 +1638,20 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
              'requiredCSSModules': requiredCSSModules},
             self._flatten, tags.div(xmlns="http://www.w3.org/1999/xhtml")[self]).decode('utf-8')
 
+        print(1641, children)
         del children[0]
 
         self._structuredCache = {
             'requiredModules': [(name, flat.flatten(url).decode('utf-8'))
-                                 for (name, url) in requiredModules],
+                                for (name, url) in requiredModules],
             'requiredCSSModules': [flat.flatten(url).decode('utf-8')
-                                    for url in requiredCSSModules],
+                                   for url in requiredCSSModules],
             'class': self.jsClass,
             'id': self._athenaID,
             'initArguments': tuple(self.getInitialArguments()),
             'markup': markup,
             'children': children}
         return self._structuredCache
-
 
     def liveElement(self, request, tag):
         """
@@ -1745,9 +1669,9 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         # This will only be set if _structured() is being run.
         if context.get('children') is not None:
             context.get('children').append({
-                    'class': self.jsClass,
-                    'id': self._athenaID,
-                    'initArguments': self.getInitialArguments()})
+                'class': self.jsClass,
+                'id': self._athenaID,
+                'initArguments': self.getInitialArguments()})
             context.get('requiredModules').extend(requiredModules)
             context.get('requiredCSSModules').extend(requiredCSSModules)
             return tag
@@ -1773,17 +1697,15 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
 
             # Okay, application stuff, plus metadata
             tag,
-            )
-    renderer(liveElement)
+        )
 
+    renderer(liveElement)
 
     def render_liveFragment(self, ctx, data):
         return self.liveElement(inevow.IRequest(ctx), ctx.tag)
 
-
     def getImportStan(self, moduleName):
         return self.page.getImportStan(moduleName)
-
 
     def locateMethod(self, ctx, methodName):
         remoteMethod = expose.get(self, methodName, None)
@@ -1791,14 +1713,12 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
             raise AttributeError(self, methodName)
         return remoteMethod
 
-
     def callRemote(self, methodName, *varargs):
         return self.page.callRemote(
             "Nevow.Athena.callByAthenaID",
             self._athenaID,
             methodName,
             varargs)
-
 
     def _athenaDetachServer(self):
         """
@@ -1818,8 +1738,8 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         if page._didConnect:
             self.connectionLost(ConnectionLost('Detached'))
         self.detached()
-    expose(_athenaDetachServer)
 
+    expose(_athenaDetachServer)
 
     def detach(self):
         """
@@ -1836,7 +1756,6 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         d.addCallback(lambda ign: self._athenaDetachServer())
         return d
 
-
     def detached(self):
         """
         Application-level callback invoked when L{detach} succeeds or when the
@@ -1848,14 +1767,12 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         Override this.
         """
 
-
     def connectionMade(self):
         """
         Callback invoked when the transport is first available to this widget.
 
         Override this.
         """
-
 
     def connectionLost(self, reason):
         """
@@ -1868,7 +1785,6 @@ class _LiveMixin(_HasJSClass, _HasCSSModule):
         """
 
 
-
 class LiveFragment(_LiveMixin, rend.Fragment):
     """
     This class is deprecated because it relies on context objects
@@ -1876,12 +1792,12 @@ class LiveFragment(_LiveMixin, rend.Fragment):
 
     @see: L{LiveElement}
     """
+
     def __init__(self, *a, **kw):
         super(LiveFragment, self).__init__(*a, **kw)
         warnings.warn("[v0.10] LiveFragment has been superceded by LiveElement.",
                       category=DeprecationWarning,
                       stacklevel=2)
-
 
     def rend(self, context, data):
         """
@@ -1892,8 +1808,6 @@ class LiveFragment(_LiveMixin, rend.Fragment):
         context = rend.Fragment.rend(self, context, data)
         self._prepare(context.tag)
         return context
-
-
 
 
 class LiveElement(_LiveMixin, Element):
@@ -1984,6 +1898,7 @@ class LiveElement(_LiveMixin, Element):
 
     syntax as is provided for Javascript modules.
     """
+
     def render(self, request):
         """
         Hook into the rendering process in order to check preconditions and
@@ -1993,7 +1908,6 @@ class LiveElement(_LiveMixin, Element):
         document = tags.invisible[Element.render(self, request)]
         self._prepare(document)
         return document
-
 
 
 class IntrospectionFragment(LiveFragment):
@@ -2006,10 +1920,9 @@ class IntrospectionFragment(LiveFragment):
 
     docFactory = loaders.stan(
         tags.span(render=tags.directive('liveFragment'))[
-        tags.a(
-        href="#DEBUG_ME",
-        class_='toggle-debug')["Debug"]])
-
+            tags.a(
+                href="#DEBUG_ME",
+                class_='toggle-debug')["Debug"]])
 
 
 __all__ = [
@@ -2032,4 +1945,4 @@ __all__ = [
 
     # Decorators
     'expose', 'handler',
-    ]
+]

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1529,9 +1529,12 @@ def _rewriteEventHandlerToAttribute(tag):
                 info = tag.children.pop(i)
                 name = info.attributes['event'].encode('ascii')
                 handler = info.attributes['handler']
-                extraAttributes[unicode(name)] = _handlerFormat % {
-                    b'handler': json.serialize(bytes(handler, 'ascii')),
-                    b'event': json.serialize(bytes(name, 'ascii'))}
+                kw={
+                    b'handler': json.serialize(unicode(handler, 'ascii')),
+                    b'event': json.serialize(unicode(name, 'ascii'))}
+                print(1535,kw)
+                
+                extraAttributes[unicode(name)] = _handlerFormat % kw
                 tag(**extraAttributes)
     return tag
 

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -299,7 +299,7 @@ def _collectPackageBelow(baseDir, extension):
             path = os.path.join(root, dir, '__init__.' + extension)
             if not os.path.exists(path):
                 path = EMPTY
-            mapping[str(name, 'ascii')] = path
+            mapping[unicode(name, 'ascii')] = path
             _revMap[os.path.join(root, dir)] = name + '.'
 
         for fn in filenames:
@@ -395,6 +395,7 @@ class JSDependencies(object):
             self._loadPlugins = False
 
         jsMod = className
+        print(398, jsMod, self.mapping)
         while jsMod:
             try:
                 self.mapping[jsMod]

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1359,7 +1359,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
         moduleDef = jsModuleDeclaration(moduleName);
         
         t=tags.script(type='text/javascript')
-        r=tags.raw(moduleDef)
+        r=tags.raw(toBytes(moduleDef))
         t[r]
         
         return [t,

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -1515,7 +1515,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
 handler = stan.Proto('athena:handler')
-_handlerFormat = "return Nevow.Athena.Widget.handleEvent(this, %(event)s, %(handler)s);"
+_handlerFormat = b"return Nevow.Athena.Widget.handleEvent(this, %(event)s, %(handler)s);"
 
 def _rewriteEventHandlerToAttribute(tag):
     """

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -12,7 +12,7 @@ from twisted import plugin
 from nevow import inevow, plugins, flat, _flat
 from nevow import rend, loaders, static
 from nevow import json, util, tags, guard, stan
-from nevow.util import CachedFile, unicode, toBytes
+from nevow.util import CachedFile, unicode, toBytes, getEncoding
 from nevow.useragent import UserAgent, browsers
 from nevow.url import here, URL
 
@@ -185,7 +185,7 @@ class AthenaModule(object):
         """
         Calculate our dependencies given the path to our source.
         """
-        depgen = self._extractImports(open(jsFile, 'rU'))
+        depgen = self._extractImports(open(jsFile, 'rU', encoding=getEncoding(jsFile)))
         return self.packageDeps + list(dict.fromkeys(depgen).keys())
 
 
@@ -1513,7 +1513,7 @@ class LivePage(rend.Page, _HasJSClass, _HasCSSModule):
 
 
 handler = stan.Proto('athena:handler')
-_handlerFormat = b"return Nevow.Athena.Widget.handleEvent(this, %(event)s, %(handler)s, event);"
+_handlerFormat = b"return Nevow.Athena.Widget.handleEvent(this, %(event)s, %(handler)s);"
 
 def _rewriteEventHandlerToAttribute(tag):
     """

--- a/nevow/athena.py
+++ b/nevow/athena.py
@@ -185,7 +185,7 @@ class AthenaModule(object):
         """
         Calculate our dependencies given the path to our source.
         """
-        depgen = self._extractImports(file(jsFile, 'rU'))
+        depgen = self._extractImports(open(jsFile, 'rU'))
         return self.packageDeps + list(dict.fromkeys(depgen).keys())
 
 

--- a/nevow/blocks.py
+++ b/nevow/blocks.py
@@ -140,7 +140,7 @@ class _Blocks(object):
             _class=self.className,
             style='; '.join(
                 [': '.join((k.replace('_', '-'), v))
-                for (k, v) in kw.items()]))
+                for (k, v) in list(kw.items())]))
 
 
 block = _Blocks(tags.span, 'nevow-blocks-block')

--- a/nevow/blocks.py
+++ b/nevow/blocks.py
@@ -34,7 +34,7 @@ background images generally appear to be safe.
 It doesn't appear to be possible to set the vertical-align in some cases in mozilla.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import static
 from nevow import inevow
@@ -147,6 +147,7 @@ block = _Blocks(tags.span, 'nevow-blocks-block')
 line = _Blocks(tags.div, 'nevow-blocks-line')
 
 
+@implementer(inevow.IRenderer)
 class collapser(object):
     """Render a fragment of html with a head and a body.
     The body can be in two states, expanded and collapsed.
@@ -159,7 +160,6 @@ class collapser(object):
     and a div, and you can omit the visibility image if desired (js would have 
     to change too)
     """
-    implements(inevow.IRenderer)
 
     def __init__(self, headCollapsed, headExpanded, body, collapsed=True):
         self.headCollapsed = headCollapsed

--- a/nevow/canvas.py
+++ b/nevow/canvas.py
@@ -11,7 +11,7 @@ from nevow.flat import flatten
 from nevow.stan import Proto, Tag
 from itertools import count
 
-cn = count().next
+cn = count().__next__
 cookie = lambda: str(cn())
 
 _hookup = {}
@@ -193,7 +193,7 @@ class GroupBase(object):
             l[[a(v=x) for x in colors]],
             l[[a(v=x) for x in alphas]],
             l[[a(v=x) for x in ratios]],
-            d[[i(k=k, v=v) for (k, v) in matrix.items()]])
+            d[[i(k=k, v=v) for (k, v) in list(matrix.items())]])
 
     def text(self, text, x, y, height, width):
         """Place the given text on the canvas using the given x, y, height and width.
@@ -212,7 +212,7 @@ class GroupBase(object):
         cook = cookie()
         I = Image(cook, self)
         self.call('image', cook, where)
-        print "IMAGE", where
+        print("IMAGE", where)
         return I
 
     def sound(self, where, stream=True):
@@ -354,18 +354,18 @@ class CanvasSocket(GroupBase):
 
     def handle_onMouseUp(self, info):
         if self.delegate.onMouseUp:
-            self.delegate.onMouseUp(self, *map(int, map(float, info.split())))
+            self.delegate.onMouseUp(self, *list(map(int, list(map(float, info.split())))))
 
     def handle_onMouseDown(self, info):
         if self.delegate.onMouseDown:
-            self.delegate.onMouseDown(self, *map(int, map(float, info.split())))
+            self.delegate.onMouseDown(self, *list(map(int, list(map(float, info.split())))))
 
     def handle_onMouseMove(self, info):
         if self.delegate.onMouseMove:
-            self.delegate.onMouseMove(self, *map(int, map(float, info.split())))
+            self.delegate.onMouseMove(self, *list(map(int, list(map(float, info.split())))))
 
     def handle_diagnostic(self, info):
-        print "Trace", info
+        print("Trace", info)
 
 canvasServerMessage = loaders.stan(tags.html["This server dispatches for nevow canvas events."])
 

--- a/nevow/canvas.py
+++ b/nevow/canvas.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import defer
 from twisted.python import log
@@ -282,12 +282,11 @@ class Group(GroupBase):
         """
         return 0
 
-
+@implementer(inevow.IResource)
 class CanvasSocket(GroupBase):
     """An object which represents the client-side canvas. Defines APIs for drawing
     on the canvas. An instance of this class will be passed to your onload callback.
     """
-    implements(inevow.IResource)
 
     groupName = 'canvas'
 

--- a/nevow/compression.py
+++ b/nevow/compression.py
@@ -109,7 +109,7 @@ class CompressingRequestWrapper(_makeBase()):
 
     def __init__(self, underlying):
         self.underlying = underlying
-        self.setHeader('content-encoding', self.encoding)
+        self.setHeader(b'content-encoding', self.encoding)
         self._gzipFile = None
 
         # See setHeader docstring for more commentary.

--- a/nevow/compression.py
+++ b/nevow/compression.py
@@ -4,7 +4,7 @@ Implementation of on-the-fly content compression for HTTP resources.
 """
 from gzip import GzipFile
 
-from zope.interface import implements
+from zope.interface import implementer as implements
 
 from twisted.internet.defer import maybeDeferred, Deferred
 from twisted.internet.interfaces import IConsumer
@@ -89,6 +89,7 @@ def _makeBase():
             d[attrName] = _ProxyDescriptor(attrName)
     return type('_CompressionRequestWrapperBase', (object,), d)
 
+@implements(IRequest)
 class CompressingRequestWrapper(_makeBase()):
     """
     A request wrapper with support for transport encoding compression.
@@ -100,7 +101,7 @@ class CompressingRequestWrapper(_makeBase()):
     @ivar compressLevel: the level of gzip compression to apply.
     @type compressLevel: C{int}
     """
-    implements(IRequest)
+    
 
     encoding = 'gzip'
     compressLevel = 6
@@ -151,7 +152,7 @@ class CompressingRequestWrapper(_makeBase()):
         self.underlying.finishRequest(success)
 
 
-
+@implements(IResource)
 class CompressingResourceWrapper(object):
     """
     A resource wrapper with support for transport encoding compression.
@@ -159,7 +160,6 @@ class CompressingResourceWrapper(object):
     @ivar underlying: the resource being wrapped.
     @type underlying: L{IResource}
     """
-    implements(IResource)
 
     def __init__(self, underlying):
         self.underlying = underlying

--- a/nevow/compy.py
+++ b/nevow/compy.py
@@ -35,8 +35,7 @@ def registerAdapter(adapterFactory, origInterface, *interfaceClasses):
         origInterface = _namedAnyWithBuiltinTranslation(origInterface)
         interfaceClasses = [_namedAnyWithBuiltinTranslation(x) for x in interfaceClasses]
 
-    if 'nevow.inevow.ISerializable' in interfaceClasses or filter(
-            lambda o: getattr(o, '__name__', None) == 'ISerializable', interfaceClasses):
+    if 'nevow.inevow.ISerializable' in interfaceClasses or [o for o in interfaceClasses if getattr(o, '__name__', None) == 'ISerializable']:
         warnings.warn("ISerializable is deprecated. Please use nevow.flat.registerFlattener instead.", stacklevel=2)
         from nevow import flat
         flat.registerFlattener(adapterFactory, origInterface)
@@ -53,7 +52,7 @@ class Componentized(_Componentized):
     def __init__(self, adapterCache=None):
         _Componentized.__init__(self)
         if adapterCache:
-            for k, v in adapterCache.items():
+            for k, v in list(adapterCache.items()):
                 self.setComponent(k, v)
 
 

--- a/nevow/compy.py
+++ b/nevow/compy.py
@@ -7,7 +7,7 @@ so that nevow works with it.
 
 import warnings
 
-from zope.interface import Interface, implements as zimplements, Attribute
+from zope.interface import Interface, implementer as zimplements, Attribute
 
 from twisted.python.components import *
 
@@ -46,8 +46,9 @@ class IComponentized(Interface):
     pass
 
 _Componentized = Componentized
+@zimplements(IComponentized)
 class Componentized(_Componentized):
-    zimplements(IComponentized)
+    
     
     def __init__(self, adapterCache=None):
         _Componentized.__init__(self)

--- a/nevow/context.py
+++ b/nevow/context.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from __future__ import generators
+
 
 import warnings
 
@@ -109,7 +109,7 @@ class WebContext(object):
 
             contextParent = currentContext.parent
             if contextParent is None:
-                raise KeyError, "Interface %s was not remembered." % key
+                raise KeyError("Interface %s was not remembered." % key)
 
             currentContext = contextParent
 
@@ -151,7 +151,7 @@ class WebContext(object):
                 if data is not Unset:
                     return data
             if currentContext.parent is None:
-                raise KeyError, "Slot named '%s' was not filled." % name
+                raise KeyError("Slot named '%s' was not filled." % name)
             currentContext = currentContext.parent
 
     def clone(self, deep=True, cloneTags=True):

--- a/nevow/dirlist.py
+++ b/nevow/dirlist.py
@@ -5,7 +5,7 @@
 
 # system imports
 import os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import stat
 
 # twisted imports
@@ -49,7 +49,7 @@ class DirectoryLister(rend.Page):
         files = []; dirs = []
 
         for path in directory:
-            url = urllib.quote(path, '/')
+            url = urllib.parse.quote(path, '/')
             if os.path.isdir(os.path.join(self.path, path)):
                 url = url + '/'
                 dirs.append({
@@ -65,7 +65,7 @@ class DirectoryLister(rend.Page):
                     self.contentTypes, self.contentEncodings, self.defaultType)
                 try:
                     filesize = os.stat(os.path.join(self.path, path))[stat.ST_SIZE]
-                except OSError, x:
+                except OSError as x:
                     if x.errno != 2 and x.errno != 13:
                         raise x
                 else:
@@ -80,7 +80,7 @@ class DirectoryLister(rend.Page):
 
     def data_header(self, context, data):
         request = context.locate(inevow.IRequest)
-        return "Directory listing for %s" % urllib.unquote(request.uri)
+        return "Directory listing for %s" % urllib.parse.unquote(request.uri)
 
     def render_tableLink(self, context, data):
         return tags.a(href=data['link'])[data['linktext']]

--- a/nevow/dirlist.py
+++ b/nevow/dirlist.py
@@ -80,7 +80,7 @@ class DirectoryLister(rend.Page):
 
     def data_header(self, context, data):
         request = context.locate(inevow.IRequest)
-        return "Directory listing for %s" % urllib.parse.unquote(request.uri)
+        return "Directory listing for %s" % urllib.parse.unquote(request.uri.decode('ascii'))
 
     def render_tableLink(self, context, data):
         return tags.a(href=data['link'])[data['linktext']]

--- a/nevow/entities.py
+++ b/nevow/entities.py
@@ -10,7 +10,8 @@ import types
 
 __by_number = {}
 
-def makeEntity((name, num, description)):
+def makeEntity(xxx_todo_changeme):
+    (name, num, description) = xxx_todo_changeme
     from nevow.stan import Entity
     e = Entity(name, num, description)
     __by_number[types.IntType(num)] = e

--- a/nevow/events.py
+++ b/nevow/events.py
@@ -16,7 +16,7 @@ class EventNotification:
         Returns a token which should be passed to unsubscribe when done.
         """
         if DEBUG:
-            print "SUBSCRIBE", self, identifier, subscriber
+            print("SUBSCRIBE", self, identifier, subscriber)
         self._subscribers.setdefault(identifier, []).append(subscriber)
         return identifier, subscriber
 
@@ -24,7 +24,7 @@ class EventNotification:
         """Unsubscribe the given token from events.
         """
         if DEBUG:
-            print "UNSUBSCRIBE", token
+            print("UNSUBSCRIBE", token)
         identifier, reference = token
         self._subscribers[identifier].remove(reference)
 
@@ -32,14 +32,14 @@ class EventNotification:
         """Notify the listeners on a given identifier that an event has occurred.
         """
         if DEBUG:
-            print "PUBLISH", self, identifier,
+            print("PUBLISH", self, identifier, end=' ')
         subscribers = self._subscribers.get(identifier, [])
         for sub in subscribers:
             sub(*args)
             if DEBUG:
-                print "NOTIFY SUBSCRIBER", sub
+                print("NOTIFY SUBSCRIBER", sub)
         if DEBUG:
-            print "done"
+            print("done")
 
     def nextId(self):
         self._currentId += 1

--- a/nevow/failure.py
+++ b/nevow/failure.py
@@ -164,7 +164,7 @@ def htmlDict(d):
                 t.td(_class="dictKey")[ k == '__builtins__' and 'builtin dictionary' or htmlrepr(k) ],
                 t.td(_class="dictValue")[ htmlrepr(v) ]
             ]
-            for k, v in d.items()
+            for k, v in list(d.items())
         ]]
     ]
                 
@@ -189,13 +189,13 @@ def htmlString(s):
 
 def htmlFunc(f):
     return t.div(_class="function")[
-        "Function %s in file %s at line %s" % (f.__name__, f.func_code.co_filename, f.func_code.co_firstlineno)
+        "Function %s in file %s at line %s" % (f.__name__, f.__code__.co_filename, f.__code__.co_firstlineno)
     ]
 
 
 def htmlMeth(m):
     return t.div(_class="method")[
-        "Method %s in file %s at line %s" % (m.im_func.__name__, m.im_func.func_code.co_filename, m.im_func.func_code.co_firstlineno)
+        "Method %s in file %s at line %s" % (m.__func__.__name__, m.__func__.__code__.co_filename, m.__func__.__code__.co_firstlineno)
     ]
 
 def htmlUnknown(u):
@@ -205,10 +205,10 @@ def htmlUnknown(u):
 
 
 htmlReprTypes = {
-    types.DictType: htmlDict,
-    types.ListType: htmlList,
+    dict: htmlDict,
+    list: htmlList,
     types.InstanceType: htmlInst,
-    types.StringType: htmlString,
+    bytes: htmlString,
     types.FunctionType: htmlFunc,
     types.MethodType: htmlMeth,
 }
@@ -282,7 +282,7 @@ def formatFailure(myFailure):
         # Instance variables
         for name, var in localVars:
             if name == 'self' and hasattr(var, '__dict__'):
-                usedVars = [ (key, value) for (key, value) in var.__dict__.items()
+                usedVars = [ (key, value) for (key, value) in list(var.__dict__.items())
                              if re.search(r'\Wself.%s\W' % (re.escape(key),), textSnippet) ]
                 if usedVars:
                     frame[

--- a/nevow/failure.py
+++ b/nevow/failure.py
@@ -207,7 +207,6 @@ def htmlUnknown(u):
 htmlReprTypes = {
     dict: htmlDict,
     list: htmlList,
-    types.InstanceType: htmlInst,
     bytes: htmlString,
     types.FunctionType: htmlFunc,
     types.MethodType: htmlMeth,

--- a/nevow/flat/flatmdom.py
+++ b/nevow/flat/flatmdom.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from __future__ import generators
+
 
 from nevow.flat import serialize, precompile
 from nevow.stan import Tag, xml, directive, slot, cdata
@@ -50,7 +50,7 @@ def MicroDomElementSerializer(element, context):
     specials = {}
     attributes = attributeList
     directives = directiveMapping
-    for k, v in attrs.items():
+    for k, v in list(attrs.items()):
         # I know, this is totally not the way to do xml namespaces but who cares right now
         ## I'll fix it later -dp
         ### no you won't *I'll* fix it later -glyph

--- a/nevow/flat/flatsax.py
+++ b/nevow/flat/flatsax.py
@@ -132,7 +132,7 @@ class ToStan(handler.ContentHandler, handler.EntityResolver):
         specials = {}
         attributes = self.attributeList
         directives = self.directiveMapping
-        for k, v in attrs.items():
+        for k, v in list(attrs.items()):
             att_ns, nons = k
             if att_ns != nevow.namespace:
                 continue
@@ -145,7 +145,7 @@ class ToStan(handler.ContentHandler, handler.EntityResolver):
                 del attrs[k]
 
         no_ns_attrs = {}
-        for (attrNs, attrName), v in attrs.items():
+        for (attrNs, attrName), v in list(attrs.items()):
             nsPrefix = self.prefixMap.get(attrNs)
             if nsPrefix is None:
                 no_ns_attrs[attrName] = v
@@ -248,5 +248,5 @@ def parse(fl, ignoreDocType=False, ignoreComment=False):
     return s.document
 
 def parseString(t, ignoreDocType=False, ignoreComment=False):
-    from cStringIO import StringIO
+    from io import StringIO
     return parse(StringIO(t), ignoreDocType, ignoreComment)

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from __future__ import generators
 
-import urllib, warnings
+
+import urllib.request, urllib.parse, urllib.error, warnings
 
 from twisted.python import log, failure
 
@@ -38,7 +38,7 @@ def TagSerializer(original, context, contextIsMine=False):
     visible = bool(original.tagName)
     
     if visible and context.isAttrib:
-        raise RuntimeError, "Tried to render tag '%s' in an tag attribute context." % (original.tagName)
+        raise RuntimeError("Tried to render tag '%s' in an tag attribute context." % (original.tagName))
 
     if context.precompile and original.macro:
         toBeRenderedBy = original.macro
@@ -53,7 +53,7 @@ def TagSerializer(original, context, contextIsMine=False):
     ## TODO: Do we really need to bypass precompiling for *all* specials?
     ## Perhaps just render?
     if context.precompile and (
-        [x for x in original._specials.values() 
+        [x for x in list(original._specials.values()) 
         if x is not None and x is not Unset]
         or original.slotData):
         ## The tags inside this one get a "fresh" parent chain, because
@@ -111,7 +111,7 @@ def TagSerializer(original, context, contextIsMine=False):
     yield '<%s' % original.tagName
     if original.attributes:
         attribContext = WovenContext(parent=context, precompile=context.precompile, isAttrib=True)
-        for (k, v) in sorted(original.attributes.iteritems()):
+        for (k, v) in sorted(original.attributes.items()):
             if v is None:
                 continue
             yield ' %s="' % k
@@ -155,7 +155,7 @@ def StringSerializer(original, context):
     if context.inURL:
         # The magic string "-_.!*'()" also appears in url.py.  Thinking about
         # changing this?  Change that, too.
-        return urllib.quote(original, safe="-_.!*'()")
+        return urllib.parse.quote(original, safe="-_.!*'()")
     ## quote it
     if context.inJS:
         original = _jsSingleQuoteQuote(original)
@@ -235,7 +235,7 @@ def FunctionSerializer(original, context, nocontextfun=FunctionSerializer_nocont
                 else:
                     result = original(context, data)
         except StopIteration:
-            raise RuntimeError, "User function %r raised StopIteration." % original
+            raise RuntimeError("User function %r raised StopIteration." % original)
         return serialize(result, context)
 
 

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -229,7 +229,8 @@ def FunctionSerializer(original, context, nocontextfun=FunctionSerializer_nocont
         try:
             nocontext = nocontextfun(original)
             if nocontext is True:
-                if original.__code__.co_argcount==3:
+                if hasattr(original, '__code__') and (original.__code__.co_argcount == 3 or (
+                            original.__code__.co_argcount == 2 and original.__code__.co_varnames[0] != 'self')):
                     result = original(context, data)
                 else:
                     result = original(data)

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -13,6 +13,7 @@ from nevow.inevow import ICanHandleException, IData, IMacroFactory, IRenderer, I
 from nevow.flat import precompile, serialize
 from nevow.accessors import convertToData
 from nevow.context import WovenContext
+from nevow.util import toBytes, unicode
 
 allowSingleton = ('img', 'br', 'hr', 'base', 'meta', 'link', 'param', 'area',
                   'input', 'col', 'basefont', 'isindex', 'frame')

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -166,7 +166,7 @@ def StringSerializer(original, context):
     elif context.inJS:
         return original
     else:
-        return original.replace(b"&", b"&amp;").replace(b"<", "&lt;").replace(b">", "&gt;")
+        return original.replace(b"&", b"&amp;").replace(b"<", b"&lt;").replace(b">", b"&gt;")
 
 
 def NoneWarningSerializer(original, context):

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -152,6 +152,7 @@ def StringSerializer(original, context):
     # alphanumeric and a few punctation characters are valid.
     # Otherwise we use normal XML escaping rules but also replacing "
     # in an attribute because Nevow always uses "..." for values.
+    original=toBytes(original)
     if context.inURL:
         # The magic string "-_.!*'()" also appears in url.py.  Thinking about
         # changing this?  Change that, too.

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -227,7 +227,7 @@ def FunctionSerializer(original, context, nocontextfun=FunctionSerializer_nocont
         try:
             nocontext = nocontextfun(original)
             if nocontext is True:
-                result = original(data)
+                result = original(None, data)
             else:
                 if nocontext is PASS_SELF:
                     renderer = context.locate(IRenderer)

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -227,7 +227,10 @@ def FunctionSerializer(original, context, nocontextfun=FunctionSerializer_nocont
         try:
             nocontext = nocontextfun(original)
             if nocontext is True:
-                result = original(None, data)
+                if original.__code__.co_argcount==3:
+                    result = original(context, data)
+                else:
+                    result = original(data)
             else:
                 if nocontext is PASS_SELF:
                     renderer = context.locate(IRenderer)

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -164,7 +164,7 @@ def StringSerializer(original, context):
         if not context.inJSSingleQuoteString:
             original = b"'%s'" % (original, )
     if context.isAttrib:
-        return original.replace(b"&", "&amp;").replace(b"<", b"&lt;").replace(b">", b"&gt;").replace(b'"', b"&quot;")
+        return original.replace(b"&", b"&amp;").replace(b"<", b"&lt;").replace(b">", b"&gt;").replace(b'"', b"&quot;")
     elif context.inJS:
         return original
     else:

--- a/nevow/flat/flatstan.py
+++ b/nevow/flat/flatstan.py
@@ -160,24 +160,24 @@ def StringSerializer(original, context):
     if context.inJS:
         original = _jsSingleQuoteQuote(original)
         if not context.inJSSingleQuoteString:
-            original = "'%s'" % (original, )
+            original = b"'%s'" % (original, )
     if context.isAttrib:
-        return original.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+        return original.replace(b"&", "&amp;").replace(b"<", b"&lt;").replace(b">", b"&gt;").replace(b'"', b"&quot;")
     elif context.inJS:
         return original
     else:
-        return original.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        return original.replace(b"&", b"&amp;").replace(b"<", "&lt;").replace(b">", "&gt;")
 
 
 def NoneWarningSerializer(original, context):
     if context.isAttrib:
         ## We don't want the big red None warning inside a html attribute. Just leave it blank.
-        return ''
+        return b''
     elif context.inURL:
-        return ''
+        return b''
     elif context.inJS:
-        return ''
-    return '<span style="font-size: xx-large; font-weight: bold; color: red; border: thick solid red;">None</span>'
+        return b''
+    return b'<span style="font-size: xx-large; font-weight: bold; color: red; border: thick solid red;">None</span>'
 
 
 def StringCastSerializer(original, context):
@@ -190,8 +190,8 @@ def StringCastSerializer(original, context):
 def BooleanSerializer(original, context):
     if context.inJS:
         if original:
-            return 'true'
-        return 'false'
+            return b'true'
+        return b'false'
     return str(original)
 
 

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from __future__ import generators
+
 
 import types
 import warnings
@@ -83,7 +83,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
         for item in gen:
             if isinstance(item, str):
                 straccum.append(item)
-            elif isinstance(item, unicode):
+            elif isinstance(item, str):
                 straccum.append(item.encode('utf8'))
             elif isinstance(item, (list, types.GeneratorType)):
                 # stop iterating this generator and put it back on the stack

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -113,7 +113,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
 
     if straccum:
         print(115, b''.join(straccum))
-        writer(tags.raw(b''.join(straccum)))
+        writer(tags.raw(b''.join(flatten(straccum))))
 
 
 def flatten(stan, ctx=None):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -127,7 +127,7 @@ def flatten(stan, ctx=None):
         ctx.remember(None, inevow.IData)
     result = []
     list(iterflatten(stan, ctx, result.append))
-    return tags.raw(''.join(result))
+    return tags.raw(b''.join(result))
 
 
 def precompile(stan, ctx=None):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -55,7 +55,7 @@ def partialflatten(context, obj):
     
     The return results from this function will not necessarily be a string, but will probably
     need further processing.
-    """
+    """ 
     flattener = getFlattener(obj)
     if flattener is not None:
         return flattener(obj, context)

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -93,7 +93,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
                 break
             else:
                 if straccum:
-                    writer(tags.raw(''.join(straccum)))
+                    writer(util.toBytes(tags.raw(''.join(straccum))))
                     del straccum[:]
                 if shouldYieldItem is not None and shouldYieldItem(item):
                     replacement = []

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -93,7 +93,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
                 break
             else:
                 if straccum:
-                    writer(util.toBytes(tags.raw(''.join(straccum))))
+                    writer(util.toBytes(tags.raw(b''.join(straccum))))
                     straccum=[]
                 if shouldYieldItem is not None and shouldYieldItem(item):
                     replacement = []

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -79,7 +79,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
     rest = [ iter([partialflatten(ctx, stan)]) ]
     straccum = []
     while rest:
-        print(82)
+        print(82, straccum, rest)
         gen = rest.pop()
         for item in gen:
             if isinstance(item, str):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -112,8 +112,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
                         break
 
     if straccum:
-        print(115, b''.join(straccum))
-        writer(tags.raw(b''.join(flatten(straccum))))
+        writer(tags.raw(b''.join([i for i in straccum])))
 
 
 def flatten(stan, ctx=None):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -79,6 +79,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
     rest = [ iter([partialflatten(ctx, stan)]) ]
     straccum = []
     while rest:
+        print(82)
         gen = rest.pop()
         for item in gen:
             if isinstance(item, str):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -112,7 +112,8 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
                         break
 
     if straccum:
-        writer(util.toBytes((b''.join(straccum))))
+        print(115, b''.join(straccum))
+        writer(tags.raw(b''.join(straccum)))
 
 
 def flatten(stan, ctx=None):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -113,7 +113,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
                         break
 
     if straccum:
-        writer(tags.raw(''.join(straccum)))
+        writer(util.toBytes(tags.raw(''.join(straccum))))
 
 
 def flatten(stan, ctx=None):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -112,7 +112,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
                         break
 
     if straccum:
-        writer(util.toBytes(tags.raw(b''.join(straccum))))
+        writer(util.toBytes((b''.join(straccum))))
 
 
 def flatten(stan, ctx=None):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -113,7 +113,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
                         break
 
     if straccum:
-        writer(util.toBytes(tags.raw(''.join(straccum))))
+        writer(util.toBytes(tags.raw(b''.join(straccum))))
 
 
 def flatten(stan, ctx=None):

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -82,7 +82,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
         print(82, straccum, rest)
         gen = rest.pop()
         for item in gen:
-            if isinstance(item, str):
+            if isinstance(item, bytes):
                 straccum.append(item)
             elif isinstance(item, str):
                 straccum.append(item.encode('utf8'))

--- a/nevow/flat/ten.py
+++ b/nevow/flat/ten.py
@@ -79,7 +79,6 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
     rest = [ iter([partialflatten(ctx, stan)]) ]
     straccum = []
     while rest:
-        print(82, straccum, rest)
         gen = rest.pop()
         for item in gen:
             if isinstance(item, bytes):
@@ -95,7 +94,7 @@ def iterflatten(stan, ctx, writer, shouldYieldItem=None):
             else:
                 if straccum:
                     writer(util.toBytes(tags.raw(''.join(straccum))))
-                    del straccum[:]
+                    straccum=[]
                 if shouldYieldItem is not None and shouldYieldItem(item):
                     replacement = []
                     yield item, replacement.append

--- a/nevow/flat/twist.py
+++ b/nevow/flat/twist.py
@@ -21,7 +21,7 @@ def _drive(iterable, finished):
     it after those Deferreds fire.
     """
     try:
-        next = iterable.next()
+        next = next(iterable)
     except StopIteration:
         finished.callback('')
     except:

--- a/nevow/flat/twist.py
+++ b/nevow/flat/twist.py
@@ -21,13 +21,13 @@ def _drive(iterable, finished):
     it after those Deferreds fire.
     """
     try:
-        next = next(iterable)
+        n = next(iterable)
     except StopIteration:
         finished.callback('')
     except:
         finished.errback()
     else:
-        deferred, returner = next
+        deferred, returner = n
         def cb(result):
             """
             Pass the result of a Deferred on to the callable which is

--- a/nevow/guard.py
+++ b/nevow/guard.py
@@ -18,7 +18,7 @@ except ImportError:
     from md5 import md5
 import io
 
-from zope.interface import implements
+from zope.interface import implementer
 
 # Twisted Imports
 
@@ -39,14 +39,13 @@ from nevow import inevow, url, stan
 def _sessionCookie():
     return md5("%s_%s" % (str(random.random()) , str(time.time()))).hexdigest()
 
-
+@implementer(inevow.ISession, inevow.IGuardSession)
 class GuardSession(components.Componentized):
     """A user's session with a system.
 
     This utility class contains no functionality, but is used to
     represent a session.
     """
-    implements(inevow.ISession, inevow.IGuardSession)
 
     def __init__(self, guard, uid):
         """Initialize a session with a unique ID for that session.
@@ -209,8 +208,8 @@ LOGOUT_AVATAR = '__logout__'
 
 def nomind(*args): return None
 
+@implementer(inevow.IResource)
 class Forbidden(object):
-    implements(inevow.IResource)
 
     def locateChild(self, ctx, segments):
         return self
@@ -221,6 +220,7 @@ class Forbidden(object):
         return ("<html><head><title>Forbidden</title></head>"
                 "<body><h1>Forbidden</h1>Request was forbidden.</body></html>")
 
+@implementer(inevow.IResource)
 class SessionWrapper:
     """
     SessionWrapper
@@ -241,7 +241,7 @@ class SessionWrapper:
         the browser is closed before the session timeout, both the session
         and the cookie go away.
     """
-    implements(inevow.IResource)
+    
 
     sessionLifetime = 3600
     sessionFactory = GuardSession

--- a/nevow/guard.py
+++ b/nevow/guard.py
@@ -34,10 +34,10 @@ except ImportError:
 
 # Nevow imports
 from nevow import inevow, url, stan
-
+from nevow.util import unicode, toBytes
 
 def _sessionCookie():
-    return md5("%s_%s" % (str(random.random()) , str(time.time()))).hexdigest()
+    return md5(toBytes("%s_%s" % (str(random.random()) , str(time.time())))).hexdigest()
 
 @implementer(inevow.ISession, inevow.IGuardSession)
 class GuardSession(components.Componentized):

--- a/nevow/guard.py
+++ b/nevow/guard.py
@@ -16,7 +16,7 @@ try:
     from hashlib import md5
 except ImportError:
     from md5 import md5
-import StringIO
+import io
 
 from zope.interface import implements
 
@@ -68,7 +68,7 @@ class GuardSession(components.Componentized):
         # XXX TODO: need to actually sort avatars by login order!
         if len(self.portals) != 1:
             raise RuntimeError("Ambiguous request for current avatar.")
-        return self.portals.values()[0][0]
+        return list(self.portals.values())[0][0]
 
     def resourceForPortal(self, port):
         return self.portals.get(port)
@@ -86,7 +86,7 @@ class GuardSession(components.Componentized):
             raise RuntimeError("Ambiguous request for current avatar.")
         self.setResourceForPortal(
             rsrc,
-            self.portals.keys()[0],
+            list(self.portals.keys())[0],
             logout)
 
     def setResourceForPortal(self, rsrc, port, logout):
@@ -148,7 +148,7 @@ class GuardSession(components.Componentized):
         del self.guard.sessions[self.uid]
 
         # Logout of all portals
-        for portal in self.portals.keys():
+        for portal in list(self.portals.keys()):
             self.portalLogout(portal)
 
         for c in self.expireCallbacks:
@@ -170,7 +170,7 @@ class GuardSession(components.Componentized):
         self.checkExpiredID = None
         # If I haven't been touched in 15 minutes:
         if time.time() - self.lastModified > self.lifetime / 2:
-            if self.guard.sessions.has_key(self.uid):
+            if self.uid in self.guard.sessions:
                 self.expire()
             else:
                 log.msg("no session to expire: %s" % str(self.uid))
@@ -180,7 +180,7 @@ class GuardSession(components.Componentized):
                                                     self.checkExpired)
     def __getstate__(self):
         d = self.__dict__.copy()
-        if d.has_key('checkExpiredID'):
+        if 'checkExpiredID' in d:
             del d['checkExpiredID']
         return d
 
@@ -196,7 +196,7 @@ def urlToChild(ctx, *ar, **kw):
         u = u.child(stan.xml(segment))
     if inevow.IRequest(ctx).method == 'POST':
         u = u.clear()
-    for k,v in kw.items():
+    for k,v in list(kw.items()):
         u = u.replace(k, v)
 
     return u
@@ -272,7 +272,8 @@ class SessionWrapper:
     def renderHTTP(self, ctx):
         request = inevow.IRequest(ctx)
         d = defer.maybeDeferred(self._delegate, ctx, [])
-        def _cb((resource, segments), ctx):
+        def _cb(xxx_todo_changeme1, ctx):
+            (resource, segments) = xxx_todo_changeme1
             assert not segments
             res = inevow.IResource(resource)
             return res.renderHTTP(ctx)
@@ -425,7 +426,7 @@ class SessionWrapper:
         if spoof and hasattr(session, 'args'):
             request.args = session.args
             request.fields = session.fields
-            request.content = StringIO.StringIO()
+            request.content = io.StringIO()
             request.content.close()
             request.method = session.method
             request.received_headers = session.received_headers
@@ -450,9 +451,10 @@ class SessionWrapper:
 
         if authCommand == LOGIN_AVATAR:
             subSegments = segments[1:]
-            def unmangleURL((res,segs)):
+            def unmangleURL(xxx_todo_changeme):
                 # Tell the session that we just logged in so that it will
                 # remember form values for us.
+                (res,segs) = xxx_todo_changeme
                 session.justLoggedIn = True
                 # Then, generate a redirect back to where we're supposed to be
                 # by looking at the root of the site and calculating the path
@@ -533,7 +535,8 @@ class SessionWrapper:
             self._cbLoginSuccess, session, segments
         )
 
-    def _cbLoginSuccess(self, (iface, res, logout), session, segments):
+    def _cbLoginSuccess(self, xxx_todo_changeme2, session, segments):
+        (iface, res, logout) = xxx_todo_changeme2
         session.setResourceForPortal(res, self.portal, logout)
         return res, segments
 

--- a/nevow/i18n.py
+++ b/nevow/i18n.py
@@ -209,7 +209,7 @@ def render(translator=None):
         children = ctx.tag.children
         ctx.tag.clear()
         for child in children:
-            if isinstance(child, basestring):
+            if isinstance(child, str):
                 child = translator(child)
             ctx.tag[child]
         return ctx.tag

--- a/nevow/i18n.py
+++ b/nevow/i18n.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import inevow
 
@@ -23,9 +23,8 @@ def languagesFactory(ctx):
     langs.sort(lambda a,b: cmp(b[0], a[0]))
     return [lang for quality, lang in langs]
 
-    
+@implementer(inevow.II18NConfig)
 class I18NConfig(object):
-    implements(inevow.II18NConfig)
 
     def __init__(self,
                  domain=None,

--- a/nevow/js/Nevow/Athena/__init__.js
+++ b/nevow/js/Nevow/Athena/__init__.js
@@ -1178,8 +1178,8 @@ Nevow.Athena.Widget.methods(
  * http://www.bazon.net/mishoo/articles.epl?art_id=824
  */
 Nevow.Athena.Widget._makeEventHandler = function (domEventName, methodName) {
-    return function () {
-        return Nevow.Athena.Widget.handleEvent(this, domEventName, methodName);
+    return function (e) {
+        return Nevow.Athena.Widget.handleEvent(this, domEventName, methodName, e);
     };
 };
 
@@ -1216,7 +1216,7 @@ Nevow.Athena.Widget.dispatchEvent = function (widget, eventName, handlerName, ca
  * queue to allow multiple messages from the event handler to be batched up
  * into a single request.
  */
-Nevow.Athena.Widget.handleEvent = function handleEvent(node, eventName, handlerName) {
+Nevow.Athena.Widget.handleEvent = function handleEvent(node, eventName, handlerName, event) {
     var widget = Nevow.Athena.Widget.get(node);
     var method = widget[handlerName];
     var result = false;
@@ -1226,7 +1226,7 @@ Nevow.Athena.Widget.handleEvent = function handleEvent(node, eventName, handlerN
         result = Nevow.Athena.Widget.dispatchEvent(
             widget, eventName, handlerName,
             function() {
-                return method.call(widget, node);
+                return method.call(widget, node, event);
             });
     }
     return result;

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -294,10 +294,8 @@ def _serialize(obj, w, seen):
                 w(',')
         w('}')
     elif isinstance(obj, (athena.LiveFragment, athena.LiveElement)):
-        print(297, obj)
         _serialize(obj._structured(), w, seen)
     elif isinstance(obj, (rend.Fragment, page.Element)):
-        print(299, obj)
         wrapper = tags.div(xmlns="http://www.w3.org/1999/xhtml")
         w('"')
         w(stringEncode(

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -19,16 +19,16 @@ class ParseError(ValueError):
     pass
 
 whitespace = re.compile(
-            br'('
-            br'[\r\n\t\ ]+'
-            br'|/\*.*?\*/'
-            br'|//[^\n]*[\n]'
-            br')'
+            r'('
+            r'[\r\n\t\ ]+'
+            r'|/\*.*?\*/'
+            r'|//[^\n]*[\n]'
+            r')'
             , re.VERBOSE + re.DOTALL)
-openBrace = re.compile(br'{')
-closeBrace = re.compile(br'}')
-openSquare = re.compile(br'\[')
-closeSquare = re.compile(br'\]')
+openBrace = re.compile(r'{')
+closeBrace = re.compile(r'}')
+openSquare = re.compile(r'\[')
+closeSquare = re.compile(r'\]')
 
 class StringTokenizer(object):
     """
@@ -36,12 +36,12 @@ class StringTokenizer(object):
     """
 
     def match(self, s):
-        if not s.startswith(b'"'):
+        if not s.startswith('"'):
             return None
 
         bits = []
 
-        SLASH = b"\\"
+        SLASH = "\\"
 
         IT = iter(s)
         bits = [next(IT)]
@@ -52,8 +52,8 @@ class StringTokenizer(object):
                     bits.append(next(IT))
                 except StopIteration:
                     return None
-            if char == b'"':
-                self.matched = b''.join(bits)
+            if char == '"':
+                self.matched = ''.join(bits)
                 return self
 
         return None
@@ -62,15 +62,15 @@ class StringTokenizer(object):
         return self.matched
 
 string = StringTokenizer()
-identifier = re.compile(br'[A-Za-z_][A-Za-z_0-9]*')
-colon = re.compile(br':')
-comma = re.compile(br',')
-true = re.compile(br'true')
-false = re.compile(br'false')
-null = re.compile(br'null')
-undefined = re.compile(br'undefined')
-floatNumber = re.compile(br'-?([1-9][0-9]*|0)(\.[0-9]+)([eE][-+]?[0-9]+)?')
-longNumber = re.compile(br'-?([1-9][0-9]*|0)([eE][-+]?[0-9]+)?')
+identifier = re.compile(r'[A-Za-z_][A-Za-z_0-9]*')
+colon = re.compile(r':')
+comma = re.compile(r',')
+true = re.compile(r'true')
+false = re.compile(r'false')
+null = re.compile(r'null')
+undefined = re.compile(r'undefined')
+floatNumber = re.compile(r'-?([1-9][0-9]*|0)(\.[0-9]+)([eE][-+]?[0-9]+)?')
+longNumber = re.compile(r'-?([1-9][0-9]*|0)([eE][-+]?[0-9]+)?')
 
 class StringToken(str):
     pass
@@ -82,8 +82,8 @@ class WhitespaceToken(object):
     pass
 
 def jsonlong(s):
-    if b'e' in s:
-        m, e = list(map(int, s.split(b'e', 1)))
+    if 'e' in s:
+        m, e = list(map(int, s.split('e', 1)))
     else:
         m, e = int(s), 0
     return m * 10 ** e
@@ -130,10 +130,10 @@ def accept(want, tokens):
         raise ParseError("Unexpected %r, %s expected" % (t , want))
 
 def parseValue(tokens):
-    if tokens[0] == b'{':
+    if tokens[0] == '{':
         return parseObject(tokens)
 
-    if tokens[0] == b'[':
+    if tokens[0] == '[':
         return parseList(tokens)
 
     if tokens[0] in (True, False, None):
@@ -149,11 +149,11 @@ def parseValue(tokens):
 
 
 _stringExpr = re.compile(
-    br'(?:\\x(?P<unicode>[a-fA-F0-9]{2})) # Match hex-escaped unicode' b'\n'
-    br'|' b'\n'
-    br'(?:\\u(?P<unicode2>[a-fA-F0-9]{4})) # Match hex-escaped high unicode' b'\n'
-    br'|' b'\n'
-    br'(?P<control>\\[fbntr\\"]) # Match escaped control characters' b'\n',
+    r'(?:\\x(?P<unicode>[a-fA-F0-9]{2})) # Match hex-escaped unicode' '\n'
+    r'|' '\n'
+    r'(?:\\u(?P<unicode2>[a-fA-F0-9]{4})) # Match hex-escaped high unicode' '\n'
+    r'|' '\n'
+    r'(?P<control>\\[fbntr\\"]) # Match escaped control characters' '\n',
     re.VERBOSE)
 
 _controlMap = {

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -294,8 +294,10 @@ def _serialize(obj, w, seen):
                 w(',')
         w('}')
     elif isinstance(obj, (athena.LiveFragment, athena.LiveElement)):
+        print(297, obj)
         _serialize(obj._structured(), w, seen)
     elif isinstance(obj, (rend.Fragment, page.Element)):
+        print(299, obj)
         wrapper = tags.div(xmlns="http://www.w3.org/1999/xhtml")
         w('"')
         w(stringEncode(

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -13,6 +13,7 @@ import re, types
 
 from nevow.inevow import IAthenaTransportable
 from nevow import rend, page, _flat, tags
+from nevow.util import unicode, toBytes
 
 class ParseError(ValueError):
     pass
@@ -327,6 +328,6 @@ def serialize(obj=_undefined, **kw):
         obj = kw
     L = []
     _serialize(obj, L.append, {})
-    return ''.join(L)
+    return b''.join([toBytes(i) for i in L])
 
 __all__ = ['parse', 'serialize']

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -62,15 +62,15 @@ class StringTokenizer(object):
         return self.matched
 
 string = StringTokenizer()
-identifier = re.compile(r'[A-Za-z_][A-Za-z_0-9]*')
-colon = re.compile(r':')
-comma = re.compile(r',')
-true = re.compile(r'true')
-false = re.compile(r'false')
-null = re.compile(r'null')
-undefined = re.compile(r'undefined')
-floatNumber = re.compile(r'-?([1-9][0-9]*|0)(\.[0-9]+)([eE][-+]?[0-9]+)?')
-longNumber = re.compile(r'-?([1-9][0-9]*|0)([eE][-+]?[0-9]+)?')
+identifier = re.compile(br'[A-Za-z_][A-Za-z_0-9]*')
+colon = re.compile(br':')
+comma = re.compile(br',')
+true = re.compile(br'true')
+false = re.compile(br'false')
+null = re.compile(br'null')
+undefined = re.compile(br'undefined')
+floatNumber = re.compile(br'-?([1-9][0-9]*|0)(\.[0-9]+)([eE][-+]?[0-9]+)?')
+longNumber = re.compile(br'-?([1-9][0-9]*|0)([eE][-+]?[0-9]+)?')
 
 class StringToken(str):
     pass

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -149,11 +149,11 @@ def parseValue(tokens):
 
 
 _stringExpr = re.compile(
-    br'(?:\\x(?P<unicode>[a-fA-F0-9]{2})) # Match hex-escaped unicode' '\n'
-    br'|' '\n'
-    br'(?:\\u(?P<unicode2>[a-fA-F0-9]{4})) # Match hex-escaped high unicode' '\n'
-    br'|' '\n'
-    br'(?P<control>\\[fbntr\\"]) # Match escaped control characters' '\n',
+    br'(?:\\x(?P<unicode>[a-fA-F0-9]{2})) # Match hex-escaped unicode' b'\n'
+    br'|' b'\n'
+    br'(?:\\u(?P<unicode2>[a-fA-F0-9]{4})) # Match hex-escaped high unicode' b'\n'
+    br'|' b'\n'
+    br'(?P<control>\\[fbntr\\"]) # Match escaped control characters' b'\n',
     re.VERBOSE)
 
 _controlMap = {

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -227,7 +227,7 @@ def parse(s):
     """
     Return the object represented by the JSON-encoded string C{s}.
     """
-    tokens = tokenise(s)
+    tokens = tokenise(unicode(s))
     value, tokens = parseValue(tokens)
     if tokens:
         raise ParseError("Unexpected %r" % tokens[0])

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -19,16 +19,16 @@ class ParseError(ValueError):
     pass
 
 whitespace = re.compile(
-            r'('
-            r'[\r\n\t\ ]+'
-            r'|/\*.*?\*/'
-            r'|//[^\n]*[\n]'
-            r')'
+            br'('
+            br'[\r\n\t\ ]+'
+            br'|/\*.*?\*/'
+            br'|//[^\n]*[\n]'
+            br')'
             , re.VERBOSE + re.DOTALL)
-openBrace = re.compile(r'{')
-closeBrace = re.compile(r'}')
-openSquare = re.compile(r'\[')
-closeSquare = re.compile(r'\]')
+openBrace = re.compile(br'{')
+closeBrace = re.compile(br'}')
+openSquare = re.compile(br'\[')
+closeSquare = re.compile(br'\]')
 
 class StringTokenizer(object):
     """
@@ -36,12 +36,12 @@ class StringTokenizer(object):
     """
 
     def match(self, s):
-        if not s.startswith('"'):
+        if not s.startswith(b'"'):
             return None
 
         bits = []
 
-        SLASH = "\\"
+        SLASH = b"\\"
 
         IT = iter(s)
         bits = [next(IT)]
@@ -52,8 +52,8 @@ class StringTokenizer(object):
                     bits.append(next(IT))
                 except StopIteration:
                     return None
-            if char == '"':
-                self.matched = ''.join(bits)
+            if char == b'"':
+                self.matched = b''.join(bits)
                 return self
 
         return None
@@ -82,8 +82,8 @@ class WhitespaceToken(object):
     pass
 
 def jsonlong(s):
-    if 'e' in s:
-        m, e = list(map(int, s.split('e', 1)))
+    if b'e' in s:
+        m, e = list(map(int, s.split(b'e', 1)))
     else:
         m, e = int(s), 0
     return m * 10 ** e
@@ -130,10 +130,10 @@ def accept(want, tokens):
         raise ParseError("Unexpected %r, %s expected" % (t , want))
 
 def parseValue(tokens):
-    if tokens[0] == '{':
+    if tokens[0] == b'{':
         return parseObject(tokens)
 
-    if tokens[0] == '[':
+    if tokens[0] == b'[':
         return parseList(tokens)
 
     if tokens[0] in (True, False, None):
@@ -149,11 +149,11 @@ def parseValue(tokens):
 
 
 _stringExpr = re.compile(
-    r'(?:\\x(?P<unicode>[a-fA-F0-9]{2})) # Match hex-escaped unicode' '\n'
-    r'|' '\n'
-    r'(?:\\u(?P<unicode2>[a-fA-F0-9]{4})) # Match hex-escaped high unicode' '\n'
-    r'|' '\n'
-    r'(?P<control>\\[fbntr\\"]) # Match escaped control characters' '\n',
+    br'(?:\\x(?P<unicode>[a-fA-F0-9]{2})) # Match hex-escaped unicode' '\n'
+    br'|' '\n'
+    br'(?:\\u(?P<unicode2>[a-fA-F0-9]{4})) # Match hex-escaped high unicode' '\n'
+    br'|' '\n'
+    br'(?P<control>\\[fbntr\\"]) # Match escaped control characters' '\n',
     re.VERBOSE)
 
 _controlMap = {

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -179,7 +179,7 @@ def _stringSub(m):
 def parseString(tokens):
     if type(tokens[0]) is not StringToken:
         raise ParseError("Unexpected %r" % tokens[0])
-    s = _stringExpr.sub(_stringSub, tokens.pop(0)[1:-1].decode('utf-8'))
+    s = _stringExpr.sub(_stringSub, tokens.pop(0)[1:-1])
     return s, tokens
 
 

--- a/nevow/json.py
+++ b/nevow/json.py
@@ -267,6 +267,8 @@ def _serialize(obj, w, seen):
             w('false')
     elif isinstance(obj, (int, float)):
         w(str(obj))
+    elif isinstance(obj, bytes):
+        obj=unicode(obj)
     elif isinstance(obj, str):
         w('"')
         w(stringEncode(obj))

--- a/nevow/livetrial/runner.py
+++ b/nevow/livetrial/runner.py
@@ -5,7 +5,7 @@ from nevow import athena, loaders, tags, rend, url, static, util
 staticData = filepath.FilePath(__file__).parent().child('static')
 
 class TestSuiteFragment(athena.LiveFragment):
-    jsClass = u'Nevow.Athena.Test.TestSuite'
+    jsClass = 'Nevow.Athena.Test.TestSuite'
     docFactory = loaders.stan(tags.invisible(render=tags.directive('tests')))
 
     def __init__(self, suite):
@@ -34,7 +34,7 @@ class TestSuiteFragment(athena.LiveFragment):
                 else:
                     head.append(test.head())
         gather(self.testInstances)
-        return filter(None, head)
+        return [_f for _f in head if _f]
 
 
     def render_tests(self, ctx, data):
@@ -43,7 +43,7 @@ class TestSuiteFragment(athena.LiveFragment):
 
 
 class TestRunner(TestSuiteFragment):
-    jsClass = u'Nevow.Athena.Test.TestRunner'
+    jsClass = 'Nevow.Athena.Test.TestRunner'
     docFactory = loaders.stan(
         tags.div(_class='test-runner', render=tags.directive('liveFragment'))[
             tags.form(action='#')[

--- a/nevow/livetrial/testcase.py
+++ b/nevow/livetrial/testcase.py
@@ -62,7 +62,7 @@ class TestCase(athena.LiveFragment, unittest.TestCase):
 
         Subclasses may want to override this.
         """
-        return u''
+        return ''
 
 
     def head(self):
@@ -150,11 +150,11 @@ class TestLoader(runner.TestLoader):
 
 
     def loadMethod(self, method):
-        raise NotImplementedError, 'livetests must be classes'
+        raise NotImplementedError('livetests must be classes')
 
 
     def loadClass(self, klass):
-        if not (isinstance(klass, type) or isinstance(klass, types.ClassType)):
+        if not (isinstance(klass, type) or isinstance(klass, type)):
             raise TypeError("%r is not a class" % (klass,))
         if not self.isTestCase(klass):
             raise ValueError("%r is not a test case" % (klass,))
@@ -171,7 +171,7 @@ class TestLoader(runner.TestLoader):
 
 
     def isTestCase(self, obj):
-        return isinstance(obj, (type, types.ClassType)) and issubclass(obj, TestCase) and obj is not TestCase
+        return isinstance(obj, type) and issubclass(obj, TestCase) and obj is not TestCase
 
 
     def _findTestClasses(self, module):

--- a/nevow/loaders.py
+++ b/nevow/loaders.py
@@ -24,12 +24,14 @@ import warnings
 import os.path
 from zope.interface import implementer
 
+from twisted.python.filepath import FilePath
 from twisted.python.reflect import getClass
 
 from nevow import inevow
 from nevow import flat
 from nevow.flat import flatsax
 from nevow.util import CachedFile
+
 
 @implementer(inevow.IDocFactory)
 class stan(object):
@@ -39,13 +41,6 @@ class stan(object):
     stan = None
     pattern = None
     _cache = None
-
-    def __init__(self, stan=None, pattern=None):
-        if stan is not None:
-            self.stan = stan
-        if pattern is not None:
-            self.pattern = pattern
-
 
     def load(self, ctx=None, preprocessors=()):
         if self._cache is None:
@@ -57,6 +52,13 @@ class stan(object):
                 stan = inevow.IQ(stan).onePattern(self.pattern)
             self._cache = stan
         return self._cache
+
+
+    def __init__(self, stan=None, pattern=None):
+        if stan is not None:
+            self.stan = stan
+        if pattern is not None:
+            self.pattern = pattern
 
 
 
@@ -108,10 +110,14 @@ class xmlfile(object):
     def __init__(self, template=None, pattern=None, templateDir=None, ignoreDocType=None, ignoreComment=None):
         self._cache = {}
         if template is not None:
+            if isinstance(template, FilePath):
+                template = template.path
             self.template = template
         if pattern is not None:
             self.pattern = pattern
         if templateDir is not None:
+            if isinstance(templateDir, FilePath):
+                templateDir = templateDir.path
             self.templateDir = templateDir
         if ignoreDocType is not None:
             self.ignoreDocType = ignoreDocType

--- a/nevow/loaders.py
+++ b/nevow/loaders.py
@@ -25,7 +25,6 @@ import os.path
 from zope.interface import implementer
 
 from twisted.python.reflect import getClass
-from twisted.web import microdom
 
 from nevow import inevow
 from nevow import flat
@@ -60,74 +59,7 @@ class stan(object):
         return self._cache
 
 
-@implementer(inevow.IDocFactory)
-class htmlstr(object):
-    """A document factory for HTML contained in a string"""
 
-
-    template = None
-    pattern = None
-    beExtremelyLenient = True
-    _cache = None
-
-    def __init__(self, template=None, pattern=None, beExtremelyLenient=None):
-        warnings.warn(
-            "[v0.8] htmlstr is deprecated because it's buggy. Please start using xmlfile and/or xmlstr.",
-            DeprecationWarning,
-            stacklevel=2)
-        if template is not None:
-            self.template = template
-        if pattern is not None:
-            self.pattern = pattern
-        if beExtremelyLenient is not None:
-            self.beExtremelyLenient = beExtremelyLenient
-
-    def load(self, ctx=None, preprocessors=()):
-        assert not preprocessors, "preprocessors not supported by htmlstr"
-        if self._cache is None:
-            doc = microdom.parseString(self.template, beExtremelyLenient=self.beExtremelyLenient)
-            doc = flat.precompile(doc, ctx)
-            if self.pattern is not None:
-                doc = inevow.IQ(doc).onePattern(self.pattern)
-            self._cache = doc
-        return self._cache
-
-@implementer(inevow.IDocFactory)
-class htmlfile(object):
-    """A document factory for an HTML disk template"""
-
-
-    template = None
-    pattern = None
-    templateDir = ''
-    beExtremelyLenient = True
-
-    def __init__(self, template=None, pattern=None, templateDir=None, beExtremelyLenient=None):
-        warnings.warn(
-            "[v0.8] htmlfile is deprecated because it's buggy. Please start using xmlfile and/or xmlstr.",
-            DeprecationWarning,
-            stacklevel=2)
-        if template is not None:
-            self.template = template
-        if pattern is not None:
-            self.pattern = pattern
-        if templateDir is not None:
-            self.templateDir = templateDir
-        if beExtremelyLenient is not None:
-            self.beExtremelyLenient = beExtremelyLenient
-        _filename = os.path.join(self.templateDir, self.template)
-        self._cache = CachedFile(_filename, self._reallyLoad)
-
-    def _reallyLoad(self, path, ctx):
-        doc = microdom.parse(path, beExtremelyLenient=self.beExtremelyLenient)
-        doc = flat.precompile(doc, ctx)
-        if self.pattern is not None:
-            doc = inevow.IQ(doc).onePattern(self.pattern)
-        return doc
-
-    def load(self, ctx=None, preprocessors=()):
-        assert not preprocessors, "preprocessors not supported by htmlfile"
-        return self._cache.load(ctx)
 
 @implementer(inevow.IDocFactory)
 class xmlstr(object):

--- a/nevow/loaders.py
+++ b/nevow/loaders.py
@@ -22,7 +22,7 @@ developer first ;-).
 import warnings
 
 import os.path
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python.reflect import getClass
 from twisted.web import microdom
@@ -32,11 +32,10 @@ from nevow import flat
 from nevow.flat import flatsax
 from nevow.util import CachedFile
 
-
+@implementer(inevow.IDocFactory)
 class stan(object):
     """A stan tags document factory"""
 
-    implements(inevow.IDocFactory)
 
     stan = None
     pattern = None
@@ -61,11 +60,10 @@ class stan(object):
         return self._cache
 
 
-
+@implementer(inevow.IDocFactory)
 class htmlstr(object):
     """A document factory for HTML contained in a string"""
 
-    implements(inevow.IDocFactory)
 
     template = None
     pattern = None
@@ -94,10 +92,10 @@ class htmlstr(object):
             self._cache = doc
         return self._cache
 
+@implementer(inevow.IDocFactory)
 class htmlfile(object):
     """A document factory for an HTML disk template"""
 
-    implements(inevow.IDocFactory)
 
     template = None
     pattern = None
@@ -131,9 +129,9 @@ class htmlfile(object):
         assert not preprocessors, "preprocessors not supported by htmlfile"
         return self._cache.load(ctx)
 
+@implementer(inevow.IDocFactory)
 class xmlstr(object):
 
-    implements(inevow.IDocFactory)
 
     template = None
     pattern = None
@@ -165,10 +163,9 @@ class xmlstr(object):
             self._cache = doc
         return self._cache
 
-
+@implementer(inevow.IDocFactory)
 class xmlfile(object):
 
-    implements(inevow.IDocFactory)
 
     template = None
     templateDir = None

--- a/nevow/page.py
+++ b/nevow/page.py
@@ -97,7 +97,7 @@ class Element(object):
         Load and return C{self.docFactory}.
         """
         rend = self.rend
-        if rend.im_func is not Element.__dict__['rend']:
+        if rend.__func__ is not Element.__dict__['rend']:
             context = _ctxForRequest(request, [], self, False)
             return rend(context, None)
 

--- a/nevow/page.py
+++ b/nevow/page.py
@@ -6,7 +6,7 @@ Basic rendering classes for Nevow applications.
 API Stability: Completely unstable.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow.inevow import IRequest, IRenderable, IRendererFactory
 from nevow.errors import MissingRenderMethod, MissingDocumentFactory
@@ -41,7 +41,7 @@ renderer = Expose(
     """)
 
 
-
+@implementer(inevow.IRenderable)
 class Element(object):
     """
     Base for classes which can render part of a page.
@@ -72,7 +72,6 @@ class Element(object):
     @ivar docFactory: The factory which will be used to load documents to
         return from C{render}.
     """
-    implements(IRenderable)
 
     docFactory = None
     preprocessors = ()

--- a/nevow/page.py
+++ b/nevow/page.py
@@ -17,7 +17,7 @@ from nevow.rend import _getPreprocessors
 from nevow.flat.ten import registerFlattener
 from nevow._flat import FlattenerError, _OldRendererFactory, _ctxForRequest
 from nevow._flat import deferflatten
-
+from nevow import inevow
 
 renderer = Expose(
     """

--- a/nevow/query.py
+++ b/nevow/query.py
@@ -6,10 +6,10 @@
 import twisted.python.components as tpc
 
 from nevow import inevow, stan
-from zope.interface import implements
+from zope.interface import implementer
 
+@implementer(inevow.IQ)
 class QueryContext(tpc.Adapter):
-    implements(inevow.IQ)
 
     def _locatePatterns(self, pattern, default, loop=True):
         if self.original.tag.pattern == pattern:

--- a/nevow/query.py
+++ b/nevow/query.py
@@ -47,7 +47,7 @@ class QueryList(tpc.Adapter):
                     yield x.clone(deep=False, clearPattern=True)
 
         if default is None:
-            raise stan.NodeNotFound, ("pattern", pattern)
+            raise stan.NodeNotFound("pattern", pattern)
         if hasattr(default, 'clone'):
             while True: yield default.clone(deep=False)
         else:
@@ -86,13 +86,13 @@ class QuerySlot(QueryList):
 
 class QueryNeverFind(tpc.Adapter):
     def patternGenerator(self, pattern, default=None):
-        raise stan.NodeNotFound, ('pattern', pattern)
+        raise stan.NodeNotFound('pattern', pattern)
 
     def allPatterns(self, pattern):
         return []
 
     def onePattern(self, pattern):
-        raise stan.NodeNotFound, ('pattern', pattern)
+        raise stan.NodeNotFound('pattern', pattern)
 
     def _locatePatterns(self, pattern, default, loop=True):
         return []

--- a/nevow/query.py
+++ b/nevow/query.py
@@ -66,6 +66,7 @@ class QueryList(tpc.Adapter):
         node = None
         for item in self.original:
             try:
+                print(69, type(item))
                 newNode = inevow.IQ(item).onePattern(pattern)
             except stan.NodeNotFound:
                 continue

--- a/nevow/query.py
+++ b/nevow/query.py
@@ -66,7 +66,7 @@ class QueryList(tpc.Adapter):
         node = None
         for item in self.original:
             try:
-                print(69, type(item))
+                print(69, type(item), item)
                 newNode = inevow.IQ(unicode(item)).onePattern(pattern)
             except stan.NodeNotFound:
                 continue

--- a/nevow/query.py
+++ b/nevow/query.py
@@ -4,7 +4,7 @@
 """inevow.IQ adapter implementations.
 """
 import twisted.python.components as tpc
-
+from nevow.util import unicode
 from nevow import inevow, stan
 from zope.interface import implementer
 
@@ -67,7 +67,7 @@ class QueryList(tpc.Adapter):
         for item in self.original:
             try:
                 print(69, type(item))
-                newNode = inevow.IQ(item).onePattern(pattern)
+                newNode = inevow.IQ(unicode(item)).onePattern(pattern)
             except stan.NodeNotFound:
                 continue
             else:

--- a/nevow/query.py
+++ b/nevow/query.py
@@ -66,8 +66,7 @@ class QueryList(tpc.Adapter):
         node = None
         for item in self.original:
             try:
-                print(69, type(item), item)
-                newNode = inevow.IQ(unicode(item)).onePattern(pattern)
+                newNode = inevow.IQ(item).onePattern(pattern)
             except stan.NodeNotFound:
                 continue
             else:

--- a/nevow/rend.py
+++ b/nevow/rend.py
@@ -22,7 +22,7 @@ from io import StringIO
 import random
 import warnings
 
-from zope.interface import implements, providedBy
+from zope.interface import implementer, providedBy
 
 import twisted.python.components as tpc
 from twisted.python.reflect import qual, accumulateClassList
@@ -53,9 +53,8 @@ def _getPreprocessors(inst):
     return preprocessors
 
 
-
+@implementer(inevow.IRendererFactory)
 class RenderFactory(object):
-    implements(inevow.IRendererFactory)
 
     def renderer(self, context, name):
         """Return a renderer with the given name.
@@ -88,9 +87,8 @@ class RenderFactory(object):
     render_xml = lambda self, context, data: context.tag.clear()[tags.xml(data)]
     render_data = lambda self, context, data_: data(context, data_)
 
-
+@implementer(inevow.IMacroFactory)
 class MacroFactory(object):
-    implements(inevow.IMacroFactory)
 
     def macro(self, ctx, name):
         """Return a macro with the given name.
@@ -118,9 +116,8 @@ class DataNotFoundError(Exception):
     original attribute by the DataFactory.
     """
 
-
+@implementer(inevow.IContainer)
 class DataFactory(object):
-    implements(inevow.IContainer)
 
     def child(self, context, n):
         args = []
@@ -177,7 +174,7 @@ class FreeformChildMixin:
             return carryoverHand
         return inevow.IHand(inevow.ISession(ctx), None)
 
-
+@implementer(iformless.IConfigurable)
 class ConfigurableMixin(object):
     """
     A sane L{IConfigurable} implementation for L{Fragment} and L{Page}. 
@@ -194,7 +191,6 @@ class ConfigurableMixin(object):
             assert isinstance(argName, str)
             assert isinstance(anotherArg, int)
     """
-    implements(iformless.IConfigurable)
 
     def getBindingNames(self, ctx):
         """Expose bind_* methods and attributes on this class.
@@ -258,13 +254,12 @@ class ConfigurableMixin(object):
         return util.maybeDeferred(self.getBinding, ctx, 
                                   bindingName).addCallback(_callback)
 
-
+@implementer(iformless.IConfigurableFactory)
 class ConfigurableFactory:
     """Locates configurables by looking for methods that start with
     configurable_ and end with the name of the configurable. The method
     should take a single arg (other than self) - the current context.
     """
-    implements(iformless.IConfigurableFactory)
 
     def locateConfigurable(self, context, name):
         """formless.webform.renderForms calls locateConfigurable on the IConfigurableFactory
@@ -363,7 +358,7 @@ def statusFactory(ctx):
 def originalFactory(ctx):
     return ctx.tag
 
-
+@implementer(inevow.IRenderer, inevow.IGettable)
 class Fragment(DataFactory, RenderFactory, MacroFactory, ConfigurableMixin):
     """
     This class is deprecated because it relies on context objects
@@ -371,7 +366,6 @@ class Fragment(DataFactory, RenderFactory, MacroFactory, ConfigurableMixin):
 
     @see: L{Element}
     """
-    implements(inevow.IRenderer, inevow.IGettable)
 
     docFactory = None
     original = None
@@ -512,13 +506,12 @@ class ChildLookupMixin(FreeformChildMixin):
             self.children = {}
         self.children[name] = child
 
-
+@implementer(inevow.IResource)
 class Page(Fragment, ConfigurableFactory, ChildLookupMixin):
     """A page is the main Nevow resource and renders a document loaded
     via the document factory (docFactory).
     """
 
-    implements(inevow.IResource)
 
     buffered = False
 
@@ -783,11 +776,10 @@ def data(context, data):
     """
     return context.tag.clear()[data]
 
-
+@implementer(inevow.IResource)
 class FourOhFour:
     """A simple 404 (not found) page.
     """
-    implements(inevow.IResource)
 
     notFound = "<html><head><title>Page Not Found</title></head><body>Sorry, but I couldn't find the object you requested.</body></html>"
     original = None

--- a/nevow/rend.py
+++ b/nevow/rend.py
@@ -18,7 +18,7 @@ Mostly, you'll use the renderers:
 """
 
 from time import time as now
-from cStringIO import StringIO
+from io import StringIO
 import random
 import warnings
 
@@ -33,6 +33,7 @@ from nevow.util import log
 
 import formless
 from formless import iformless, annotate
+import collections
 
 
 def _getPreprocessors(inst):
@@ -210,7 +211,7 @@ class ConfigurableMixin(object):
         described in the ConfigurableMixin class docstring.
         """
         def _get_binding(binding):
-            if callable(binding):
+            if isinstance(binding, collections.Callable):
                 binding = util.maybeDeferred(binding, ctx)
             return binding
 
@@ -298,7 +299,7 @@ class ConfigurableFactory:
         ...
         ...     docFactory = stan(render_forms).
         """
-        if filter(lambda x: issubclass(x, annotate.TypedInterface), providedBy(self)):
+        if [x for x in providedBy(self) if issubclass(x, annotate.TypedInterface)]:
             warnings.warn("[0.5] Subclassing TypedInterface to declare annotations is deprecated. Please provide bind_* methods on your Page or Fragment subclass instead.", DeprecationWarning)
             from formless import configurable
             return configurable.TypedInterfaceConfigurable(self)
@@ -329,7 +330,7 @@ def defaultsFactory(ctx):
     defaults = webform.FormDefaults()
     if co is not None:
         e = iformless.IFormErrors(co, {})
-        for k, v in e.items():
+        for k, v in list(e.items()):
             defaults.getAllDefaults(k).update(v.partialForm)
     return defaults
 
@@ -341,7 +342,7 @@ def errorsFactory(ctx):
     errs = webform.FormErrors()
     if co is not None:
         e = iformless.IFormErrors(co, {})
-        for k, v in e.items():
+        for k, v in list(e.items()):
             errs.updateErrors(k, v.errors)
             errs.setError(k, v.formErrorMessage)
     return errs
@@ -408,7 +409,7 @@ class Fragment(DataFactory, RenderFactory, MacroFactory, ConfigurableMixin):
             finally:
                 self.docFactory.pattern = old
                 self.docFactory.precompiledDoc = None
-        except TypeError, e:
+        except TypeError as e:
             # Avert your eyes now! I don't want to catch anything but IQ
             # adaption exceptions here but all I get is TypeError. This whole
             # section of code is a complete hack anyway so one more won't
@@ -546,7 +547,7 @@ class Page(Fragment, ConfigurableFactory, ChildLookupMixin):
 
         def finishRequest():
             carryover = request.args.get('_nevow_carryover_', [None])[0]
-            if carryover is not None and _CARRYOVER.has_key(carryover):
+            if carryover is not None and carryover in _CARRYOVER:
                 del _CARRYOVER[carryover]
             if self.afterRender is not None:
                 return util.maybeDeferred(self.afterRender,ctx)
@@ -668,7 +669,7 @@ class Page(Fragment, ConfigurableFactory, ChildLookupMixin):
                 magicCookie = '%s%s%s' % (now(),request.getClientIP(),random.random())
                 refpath = refpath.replace('_nevow_carryover_', magicCookie)
                 _CARRYOVER[magicCookie] = C = tpc.Componentized()
-                for k, v in aspects.iteritems():
+                for k, v in aspects.items():
                     C.setComponent(k, v)
 
             destination = flat.flatten(refpath, ctx)
@@ -768,7 +769,7 @@ def mapping(context, data):
        <td><nevow:slot name="email"/></td>
      </tr>
     """
-    for k, v in data.items():
+    for k, v in list(data.items()):
         context.fillSlots(k, v)
     return context.tag
 
@@ -799,7 +800,7 @@ class FourOhFour:
         # Look for an application-remembered handler
         try:
             notFoundHandler = ctx.locate(inevow.ICanHandleNotFound)
-        except KeyError, e:
+        except KeyError as e:
             return self.notFound
         # Call the application-remembered handler but if there are any errors
         # then log it and fallback to the standard message.
@@ -809,7 +810,7 @@ class FourOhFour:
             log.err()
             return self.notFound
 
-    def __nonzero__(self):
+    def __bool__(self):
         return False
 
 

--- a/nevow/rend.py
+++ b/nevow/rend.py
@@ -79,7 +79,7 @@ class RenderFactory(object):
         if args:
             return callable(*args)
 
-        return callable
+        return callable 
 
     render_sequence = lambda self, context, data: sequence(context, data)
     render_mapping = lambda self, context, data: mapping(context, data)

--- a/nevow/scripts/nit.py
+++ b/nevow/scripts/nit.py
@@ -50,7 +50,7 @@ def run():
     config = NitOptions()
     try:
         config.parseOptions()
-    except UsageError, ue:
+    except UsageError as ue:
         raise SystemExit("%s: %s" % (sys.argv[0], ue))
     else:
         if not config['testmodules']:

--- a/nevow/scripts/xmlgettext.py
+++ b/nevow/scripts/xmlgettext.py
@@ -1,5 +1,5 @@
 from xml.dom import pulldom
-from cStringIO import StringIO
+from io import StringIO
 from twisted.python import usage
 import nevow
 
@@ -38,14 +38,14 @@ class LineBasedStream(object):
 
 def getMsgID(node):
     out = StringIO()
-    print >>out, 'msgid ""'
+    print('msgid ""', file=out)
     for child in node.childNodes:
         s = child.toxml('utf-8')
         s = s.replace('\\', '\\\\')
         s = s.replace('"', '\\"')
         s = s.replace('\n', '\\n')
-        print >>out, '"%s"' % s
-    print >>out, 'msgstr ""'
+        print('"%s"' % s, file=out)
+    print('msgstr ""', file=out)
     return out.getvalue()
 
 def process(filename, messages):
@@ -67,14 +67,14 @@ def process(filename, messages):
 
 
 def report(messages):
-    for msgid, locations in messages.items():
+    for msgid, locations in list(messages.items()):
         for line in locations:
-            print line
-        print msgid
+            print(line)
+        print(msgid)
 
 class GettextOptions(usage.Options):
     def opt_version(self):
-        print 'Nevow version:', nevow.__version__
+        print('Nevow version:', nevow.__version__)
         usage.Options.opt_version(self)
 
     def parseArgs(self, *files):

--- a/nevow/stan.py
+++ b/nevow/stan.py
@@ -22,7 +22,7 @@ prototypes for all of the XHTML element types.
 """
 
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow import inevow
 
@@ -200,7 +200,7 @@ class _PrecompiledSlot(object):
             self.inJSSingleQuoteString)
 
 
-
+@implementer(inevow.IQ)
 class Tag(object):
     """
     Tag instances represent XML tags with a tag name, attributes, and
@@ -224,7 +224,6 @@ class Tag(object):
         the XML file from which it was parsed.  If it was not parsed from an
         XML file, C{None}.
     """
-    implements(inevow.IQ)
 
     specials = ['data', 'render', 'remember', 'pattern', 'key', 'macro']
 

--- a/nevow/stan.py
+++ b/nevow/stan.py
@@ -21,7 +21,7 @@ code. See nevow.stan.Tag for details, and nevow.tags for tag
 prototypes for all of the XHTML element types.
 """
 
-from __future__ import generators
+
 from zope.interface import implements
 
 from nevow import inevow
@@ -147,7 +147,7 @@ class slot(object):
         """Prevent an infinite loop if someone tries to do
             for x in slot('foo'):
         """
-        raise NotImplementedError, "Stan slot instances are not iterable."
+        raise NotImplementedError("Stan slot instances are not iterable.")
 
 
 
@@ -362,11 +362,11 @@ class Tag(object):
             return self
 
         for name in self.specials:
-            if kw.has_key(name):
+            if name in kw:
                 setattr(self, name, kw[name])
                 del kw[name]
 
-        for k, v in kw.iteritems():
+        for k, v in kw.items():
             if k[-1] == '_':
                 k = k[:-1]
             elif k[0] == '_':
@@ -403,7 +403,7 @@ class Tag(object):
         """Prevent an infinite loop if someone tries to do
             for x in stantaginstance:
         """
-        raise NotImplementedError, "Stan tag instances are not iterable."
+        raise NotImplementedError("Stan tag instances are not iterable.")
 
     def _clearSpecials(self):
         """Clears all the specials in this tag. For use by flatstan.
@@ -496,7 +496,7 @@ class Tag(object):
 
 
 class UnsetClass:
-    def __nonzero__(self):
+    def __bool__(self):
         return False
     def __repr__(self):
         return "Unset"
@@ -546,18 +546,18 @@ class PatternTag(object):
     through a sequence of matching patterns.'''
 
     def __init__(self, patterner):
-        self.pat = patterner.next()
+        self.pat = next(patterner)
         self.patterner = patterner
 
-    def next(self):
+    def __next__(self):
         if self.pat:
             p, self.pat = self.pat, None
             return p
-        return self.patterner.next()
+        return next(self.patterner)
 
 
 def makeForwarder(name):
-    return lambda self, *args, **kw: getattr(self.next(), name)(*args, **kw)
+    return lambda self, *args, **kw: getattr(next(self), name)(*args, **kw)
 
 for forward in ['__call__', '__getitem__', 'fillSlots']:
     setattr(PatternTag, forward, makeForwarder(forward))
@@ -591,7 +591,7 @@ def _locatePatterns(tag, pattern, default, loop=True):
                 yield cloned
 
     if default is None:
-        raise NodeNotFound, ("pattern", pattern)
+        raise NodeNotFound("pattern", pattern)
     if hasattr(default, 'clone'):
         while True:  yield default.clone(deep=False)
     else:

--- a/nevow/stan.py
+++ b/nevow/stan.py
@@ -63,7 +63,7 @@ class xml(object):
         return '<xml %r>' % self.content
 
 
-class raw(str):
+class raw(bytes):
     """Raw content marker.
 
     Raw content is never altered in any way. It is a sequence of bytes that will

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -12,7 +12,7 @@ import traceback
 import warnings
 StringIO = cStringIO
 del cStringIO
-from zope.interface import implements
+from zope.interface import implementer
 
 try:
     from twisted.web.resource import NoResource, ForbiddenResource
@@ -38,11 +38,11 @@ dangerousPathError = NoResource("Invalid request URL.")
 def isDangerous(path):
     return path == '..' or '/' in path or os.sep in path
 
+@implementer(inevow.IResource)
 class Data:
     """
     This is a static, in-memory resource.
     """
-    implements(inevow.IResource)
 
     def __init__(self, data, type, expires=None):
         self.data = data
@@ -152,6 +152,7 @@ def getTypeAndEncoding(filename, types, encodings, defaultType):
     type = types.get(ext, defaultType)
     return type, enc
 
+@implementer(inevow.IResource)
 class File:
     """
     File is a resource that represents a plain non-interpreted file
@@ -170,7 +171,6 @@ class File:
     return the contents of /tmp/foo/bar.html .
     """
 
-    implements(inevow.IResource)
 
     contentTypes = loadMimeTypes()
 
@@ -412,8 +412,8 @@ threadable.synchronize(FileTransfer)
    Inspired by Apache's mod_asis
 """
 
+@implementer(inevow.IResource)
 class ASISProcessor:
-    implements(inevow.IResource)
     
     def __init__(self, path, registry=None):
         self.path = path

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -78,10 +78,10 @@ def staticHTML(someString):
 
 
 def addSlash(request):
-    return "http%s://%s%s/" % (
-        request.isSecure() and 's' or '',
-        request.getHeader("host"),
-        (string.split(request.uri,'?')[0]))
+    return b"http%s://%s%s/" % (
+        request.isSecure() and b's' or b'',
+        request.getHeader("host").encode('ascii'),
+        (bytes.split(request.uri, b'?')[0]))
 
 class Registry(components.Componentized):
     """
@@ -289,7 +289,7 @@ class File:
         # size is the length of the part actually transmitted
         fsize = size = self.getFileSize()
 
-        request.setHeader(b'accept-ranges','bytes')
+        request.setHeader(b'accept-ranges', 'bytes')
 
         if self.type:
             request.setHeader(b'content-type', self.type)
@@ -313,10 +313,10 @@ class File:
 
             if range is not None:
                 # This is a request for partial data...
-                bytesrange = string.split(range, '=')
+                bytesrange = range.split('=')
                 assert bytesrange[0] == 'bytes',\
                        "Syntactically invalid http range header!"
-                start, end = string.split(bytesrange[1],'-')
+                start, end = bytesrange[1].split('-')
                 if start:
                     f.seek(int(start))
                 if end:
@@ -324,8 +324,8 @@ class File:
                 else:
                     end = fsize-1
                 request.setResponseCode(http.PARTIAL_CONTENT)
-                request.setHeader(b'content-range',"bytes %s-%s/%s" % (
-                    str(start), str(end), str(fsize)))
+                request.setHeader(b'content-range', "bytes %s-%i/%i" % (
+                    start, end, fsize))
                 #content-length should be the actual size of the stuff we're
                 #sending, not the full size of the on-server entity.
                 size = 1 + end - int(start)

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -338,9 +338,7 @@ class File:
             return ''
 
         # return data
-        FileTransfer(f, size, request)
-        # and make sure the connection doesn't get closed
-        return request.deferred
+        return f.read()
 
     def redirect(self, request):
         return redirectTo(addSlash(request), request)

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -361,51 +361,7 @@ class File:
         return f
 
 
-class FileTransfer(pb.Viewable):
-    """
-    A class to represent the transfer of a file over the network.
-    """
-    request = None
-    def __init__(self, file, size, request):
-        self.file = file
-        self.size = size
-        self.request = request
-        request.registerProducer(self, 0)
 
-    def resumeProducing(self):
-        if not self.request:
-            return
-        data = self.file.read(min(abstract.FileDescriptor.bufferSize, self.size))
-        if data:
-            self.request.write(data)
-            self.size -= len(data)
-        if self.size <= 0:
-            self.request.unregisterProducer()
-            self.request.finish()
-            self.request = None
-
-    def pauseProducing(self):
-        pass
-
-    def stopProducing(self):
-        self.file.close()
-        self.request = None
-
-    # Remotely relay producer interface.
-
-    def view_resumeProducing(self, issuer):
-        self.resumeProducing()
-
-    def view_pauseProducing(self, issuer):
-        self.pauseProducing()
-
-    def view_stopProducing(self, issuer):
-        self.stopProducing()
-
-
-    synchronized = ['resumeProducing', 'stopProducing']
-
-threadable.synchronize(FileTransfer)
 
 """I contain AsIsProcessor, which serves files 'As Is'
    Inspired by Apache's mod_asis

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -7,7 +7,7 @@
 
 # System Imports
 import os, string, time
-import cStringIO
+import io
 import traceback
 import warnings
 StringIO = cStringIO
@@ -144,7 +144,7 @@ def loadMimeTypes(mimetype_locations=['/etc/mime.types']):
 def getTypeAndEncoding(filename, types, encodings, defaultType):
     p, ext = os.path.splitext(filename)
     ext = ext.lower()
-    if encodings.has_key(ext):
+    if ext in encodings:
         enc = encodings[ext]
         ext = os.path.splitext(p)[1].lower()
     else:
@@ -300,7 +300,7 @@ class File:
 
         try:
             f = self.openForReading()
-        except IOError, e:
+        except IOError as e:
             import errno
             if e[0] == errno.EACCES:
                 return ForbiddenResource().render(request)

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -64,10 +64,10 @@ class Data:
 
     def renderHTTP(self, ctx):
         request = inevow.IRequest(ctx)
-        request.setHeader("content-type", self.type)
-        request.setHeader("content-length", str(len(self.data)))
+        request.setHeader(b"content-type", self.type)
+        request.setHeader(b"content-length", str(len(self.data)))
         if self.expires is not None:
-            request.setHeader("expires",
+            request.setHeader(b"expires",
                               http.datetimeToString(self.time() + self.expires))
         if request.method == "HEAD":
             return ''
@@ -289,12 +289,12 @@ class File:
         # size is the length of the part actually transmitted
         fsize = size = self.getFileSize()
 
-        request.setHeader('accept-ranges','bytes')
+        request.setHeader(b'accept-ranges','bytes')
 
         if self.type:
-            request.setHeader('content-type', self.type)
+            request.setHeader(b'content-type', self.type)
         if self.encoding:
-            request.setHeader('content-encoding', self.encoding)
+            request.setHeader(b'content-encoding', self.encoding)
 
         try:
             f = self.openForReading()
@@ -324,13 +324,13 @@ class File:
                 else:
                     end = fsize-1
                 request.setResponseCode(http.PARTIAL_CONTENT)
-                request.setHeader('content-range',"bytes %s-%s/%s" % (
+                request.setHeader(b'content-range',"bytes %s-%s/%s" % (
                     str(start), str(end), str(fsize)))
                 #content-length should be the actual size of the stuff we're
                 #sending, not the full size of the on-server entity.
                 size = 1 + end - int(start)
 
-            request.setHeader('content-length', str(size))
+            request.setHeader(b'content-length', str(size))
         except:
             traceback.print_exc(file=log.logfile)
 

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -10,8 +10,7 @@ import os, string, time
 import io
 import traceback
 import warnings
-StringIO = cStringIO
-del cStringIO
+from io import StringIO
 from zope.interface import implementer
 
 try:

--- a/nevow/static.py
+++ b/nevow/static.py
@@ -25,7 +25,6 @@ except ImportError:
     from twisted.protocols import http
 from twisted.python import threadable, log, components, filepath
 from twisted.internet import abstract
-from twisted.spread import pb
 from twisted.python.util import InsensitiveDict
 from twisted.python.runtime import platformType
 

--- a/nevow/test/acceptance/reconnect.py
+++ b/nevow/test/acceptance/reconnect.py
@@ -26,7 +26,7 @@ class ReconnectableElementRenderingLivePage(OriginalPage):
     that API.  We should not attempt to keep this working as-is; if you do find
     it in a broken state, just update it to use newer, better documented APIs.
     """
-    jsClass = u'Nevow.Test.ReconnectAcceptanceTest.ReconnectingPage'
+    jsClass = 'Nevow.Test.ReconnectAcceptanceTest.ReconnectingPage'
     def __init__(self, *a, **k):
         """
         Make sure our interface allows the particular method we want to expose.
@@ -52,7 +52,7 @@ _widget_plugin.ElementRenderingLivePage = ReconnectableElementRenderingLivePage
 
 import itertools
 
-counter = itertools.count().next
+counter = itertools.count().__next__
 
 class ReconnectableElement(LiveElement):
     """

--- a/nevow/test/acceptance/tabbedpane.py
+++ b/nevow/test/acceptance/tabbedpane.py
@@ -17,12 +17,12 @@ def tabbedPaneFragment():
     C{<h1>} node containing the tab's number.
     """
     return TabbedPaneFragment(
-        [('Page ' + str(i), tags.h1[str(i)]) for i in xrange(4)])
+        [('Page ' + str(i), tags.h1[str(i)]) for i in range(4)])
 
 
 
 class TabbedPaneFetcher(athena.LiveElement):
-    jsClass = u'Nevow.Test.TestTabbedPane.TabbedPaneFetcher'
+    jsClass = 'Nevow.Test.TestTabbedPane.TabbedPaneFetcher'
     docFactory = loaders.xmlstr("""
 <div xmlns:athena="http://divmod.org/ns/athena/0.7"
   xmlns:nevow="http://nevow.com/ns/nevow/0.1"

--- a/nevow/test/livetest_athena.py
+++ b/nevow/test/livetest_athena.py
@@ -23,15 +23,15 @@ class WidgetInitializerArguments(testcase.TestCase):
     getInitialArguments are properly passed to the widget class's __init__
     method.
     """
-    jsClass = u'Nevow.Athena.Tests.WidgetInitializerArguments'
+    jsClass = 'Nevow.Athena.Tests.WidgetInitializerArguments'
 
-    _args = [1, u"two", [3.0 for four in range(5)]]
+    _args = [1, "two", [3.0 for four in range(5)]]
 
     def getInitialArguments(self):
         return self._args
 
     def test(self, args):
-        self.assertEquals(self._args, args)
+        self.assertEqual(self._args, args)
     expose(test)
 
 
@@ -40,7 +40,7 @@ class CallRemoteTestCase(testcase.TestCase):
     """
     Test the callRemote method of Widgets.
     """
-    jsClass = u'Nevow.Athena.Tests.CallRemoteTestCase'
+    jsClass = 'Nevow.Athena.Tests.CallRemoteTestCase'
 
 
 
@@ -50,18 +50,18 @@ class ClientToServerArgumentSerialization(testcase.TestCase):
     received.
     """
 
-    jsClass = u'Nevow.Athena.Tests.ClientToServerArgumentSerialization'
+    jsClass = 'Nevow.Athena.Tests.ClientToServerArgumentSerialization'
 
     def test(self, i, f, s, l, d):
-        self.assertEquals(i, 1)
-        self.assertEquals(f, 1.5)
-        self.failUnless(isinstance(s, unicode))
-        self.assertEquals(s, u'Hello world')
-        self.failUnless(isinstance(l[2], unicode))
-        self.assertEquals(l, [1, 1.5, u'Hello world'])
-        self.assertEquals(d, {u'hello world': u'object value'})
-        self.failUnless(isinstance(d.keys()[0], unicode))
-        self.failUnless(isinstance(d.values()[0], unicode))
+        self.assertEqual(i, 1)
+        self.assertEqual(f, 1.5)
+        self.assertTrue(isinstance(s, str))
+        self.assertEqual(s, 'Hello world')
+        self.assertTrue(isinstance(l[2], str))
+        self.assertEqual(l, [1, 1.5, 'Hello world'])
+        self.assertEqual(d, {'hello world': 'object value'})
+        self.assertTrue(isinstance(list(d.keys())[0], str))
+        self.assertTrue(isinstance(list(d.values())[0], str))
     expose(test)
 
 
@@ -71,7 +71,7 @@ class ClientToServerResultSerialization(testcase.TestCase):
     received by the client.
     """
 
-    jsClass = u'Nevow.Athena.Tests.ClientToServerResultSerialization'
+    jsClass = 'Nevow.Athena.Tests.ClientToServerResultSerialization'
 
     def test(self, i, f, s, l, d):
         return (i, f, s, l, d)
@@ -85,13 +85,13 @@ class JSONRoundtrip(testcase.TestCase):
     through the real client implementation, too.
     """
 
-    jsClass = u'Nevow.Athena.Tests.JSONRoundtrip'
+    jsClass = 'Nevow.Athena.Tests.JSONRoundtrip'
 
     def test(self):
         cases = test_json.TEST_OBJECTS + test_json.TEST_STRINGLIKE_OBJECTS
         def _verifyRoundtrip(_cases):
             for v1, v2 in zip(cases, _cases):
-                self.assertEquals(v1, v2)
+                self.assertEqual(v1, v2)
         return self.callRemote('identity', cases).addCallback(_verifyRoundtrip)
     expose(test)
 
@@ -103,7 +103,7 @@ class ExceptionFromServer(testcase.TestCase):
     properly receives an error.
     """
 
-    jsClass = u'Nevow.Athena.Tests.ExceptionFromServer'
+    jsClass = 'Nevow.Athena.Tests.ExceptionFromServer'
 
     def testSync(self, s):
         raise Exception(s)
@@ -117,7 +117,7 @@ class AsyncExceptionFromServer(testcase.TestCase):
     the client properly receives an error.
     """
 
-    jsClass = u'Nevow.Athena.Tests.AsyncExceptionFromServer'
+    jsClass = 'Nevow.Athena.Tests.AsyncExceptionFromServer'
 
     def testAsync(self, s):
         return defer.fail(Exception(s))
@@ -131,7 +131,7 @@ class ExceptionFromClient(testcase.TestCase):
     properly receives an error.
     """
 
-    jsClass = u'Nevow.Athena.Tests.ExceptionFromClient'
+    jsClass = 'Nevow.Athena.Tests.ExceptionFromClient'
 
     def loopbackError(self):
         return self.callRemote('generateError').addErrback(self.checkError)
@@ -140,7 +140,7 @@ class ExceptionFromClient(testcase.TestCase):
 
     def checkError(self, f):
         f.trap(athena.JSException)
-        if u'This is a test exception' in f.value.args[0]:
+        if 'This is a test exception' in f.value.args[0]:
             return True
         else:
             raise f
@@ -153,7 +153,7 @@ class AsyncExceptionFromClient(testcase.TestCase):
     the server properly receives an error.
     """
 
-    jsClass = u'Nevow.Athena.Tests.AsyncExceptionFromClient'
+    jsClass = 'Nevow.Athena.Tests.AsyncExceptionFromClient'
 
     def loopbackError(self):
         return self.callRemote('generateError').addErrback(self.checkError)
@@ -162,7 +162,7 @@ class AsyncExceptionFromClient(testcase.TestCase):
 
     def checkError(self, f):
         f.trap(athena.JSException)
-        if u'This is a deferred test exception' in f.value.args[0]:
+        if 'This is a deferred test exception' in f.value.args[0]:
             return True
         else:
             raise f
@@ -174,10 +174,10 @@ class CustomTransportable(object):
     """
     implements(IAthenaTransportable)
 
-    jsClass = u'Nevow.Athena.Tests.CustomTransportable'
+    jsClass = 'Nevow.Athena.Tests.CustomTransportable'
 
     def getInitialArguments(self):
-        return (u"Hello", 5, u"world")
+        return ("Hello", 5, "world")
 
 
 
@@ -187,11 +187,11 @@ class ServerToClientArgumentSerialization(testcase.TestCase):
     correct arguments.
     """
 
-    jsClass = u'Nevow.Athena.Tests.ServerToClientArgumentSerialization'
+    jsClass = 'Nevow.Athena.Tests.ServerToClientArgumentSerialization'
 
     def test(self):
         return self.callRemote(
-            'reverse', 1, 1.5, u'hello', {u'world': u'value'},
+            'reverse', 1, 1.5, 'hello', {'world': 'value'},
             CustomTransportable())
     expose(test)
 
@@ -203,14 +203,14 @@ class ServerToClientResultSerialization(testcase.TestCase):
     server is correct.
     """
 
-    jsClass = u'Nevow.Athena.Tests.ServerToClientResultSerialization'
+    jsClass = 'Nevow.Athena.Tests.ServerToClientResultSerialization'
 
     def test(self):
         def cbResults(result):
-            self.assertEquals(result[0], 1)
-            self.assertEquals(result[1], 1.5)
-            self.assertEquals(result[2], u'hello')
-            self.assertEquals(result[3], {u'world': u'value'})
+            self.assertEqual(result[0], 1)
+            self.assertEqual(result[1], 1.5)
+            self.assertEqual(result[2], 'hello')
+            self.assertEqual(result[3], {'world': 'value'})
         d = self.callRemote('reverse')
         d.addCallback(cbResults)
         return d
@@ -219,7 +219,7 @@ class ServerToClientResultSerialization(testcase.TestCase):
 
 
 class WidgetInATable(testcase.TestCase):
-    jsClass = u"Nevow.Athena.Tests.WidgetInATable"
+    jsClass = "Nevow.Athena.Tests.WidgetInATable"
 
     def getTestContainer(self):
         return tags.table[tags.tbody[tags.tr[tags.td[tags.slot('widget')]]]]
@@ -227,7 +227,7 @@ class WidgetInATable(testcase.TestCase):
 
 
 class WidgetIsATable(testcase.TestCase):
-    jsClass = u"Nevow.Athena.Tests.WidgetIsATable"
+    jsClass = "Nevow.Athena.Tests.WidgetIsATable"
 
     def getWidgetTag(self):
         """
@@ -246,7 +246,7 @@ class WidgetIsATable(testcase.TestCase):
 
 
 class ParentChildRelationshipTest(testcase.TestCase):
-    jsClass = u"Nevow.Athena.Tests.ChildParentRelationshipTest"
+    jsClass = "Nevow.Athena.Tests.ChildParentRelationshipTest"
 
     def getWidgetDocument(self):
         """
@@ -260,7 +260,7 @@ class ParentChildRelationshipTest(testcase.TestCase):
         Put some children into this widget.  The client portion of this test
         will assert things about their presence in C{Widget.childWidgets}.
         """
-        for i in xrange(3):
+        for i in range(3):
             yield ChildFragment(self.page, i)
 
 
@@ -271,7 +271,7 @@ class ParentChildRelationshipTest(testcase.TestCase):
 
 
 class ChildFragment(athena.LiveFragment):
-    jsClass = u'Nevow.Athena.Tests.ChildParentRelationshipTest'
+    jsClass = 'Nevow.Athena.Tests.ChildParentRelationshipTest'
 
     docFactory = loaders.stan(tags.div(render=tags.directive('liveFragment'))[
         tags.div(render=tags.directive('childrenWidgets')),
@@ -285,7 +285,7 @@ class ChildFragment(athena.LiveFragment):
 
     def render_childrenWidgets(self, ctx, data):
         # yield tags.div['There are ', self.childCount, 'children']
-        for i in xrange(self.childCount):
+        for i in range(self.childCount):
             yield ChildFragment(self.page, self.childCount - 1)
 
 
@@ -296,7 +296,7 @@ class ChildFragment(athena.LiveFragment):
 
 
 class AutomaticClass(testcase.TestCase):
-    jsClass = u'Nevow.Athena.Tests.AutomaticClass'
+    jsClass = 'Nevow.Athena.Tests.AutomaticClass'
     docFactory = loaders.stan(tags.div(render=tags.directive('liveTest')))
 
 
@@ -313,7 +313,7 @@ class ButtonElement(Element):
 
 
 class AthenaHandler(testcase.TestCase):
-    jsClass = u'Nevow.Athena.Tests.AthenaHandler'
+    jsClass = 'Nevow.Athena.Tests.AthenaHandler'
 
     def getWidgetDocument(self):
         """
@@ -372,14 +372,14 @@ class NodeInsertedHelper(LiveElement):
     Simple widget to be dynamically instatiated for testing nodeInserted
     behaviour on client side.
     """
-    jsClass = u'Nevow.Athena.Tests.NodeInsertedHelper'
+    jsClass = 'Nevow.Athena.Tests.NodeInsertedHelper'
     docFactory = loaders.stan(
         tags.div(render=tags.directive('liveElement')))
 
 
 
 class NodeLocation(testcase.TestCase):
-    jsClass = u'Nevow.Athena.Tests.NodeLocation'
+    jsClass = 'Nevow.Athena.Tests.NodeLocation'
 
     def getWidgetDocument(self):
         """
@@ -398,13 +398,13 @@ class WidgetRequiresImport(LiveElement):
     Widget which has no behavior, but which has a JavaScript class which will
     require a dynamic import.
     """
-    jsClass = u'Nevow.Athena.Tests.Resources.ImportWidget'
+    jsClass = 'Nevow.Athena.Tests.Resources.ImportWidget'
     docFactory = loaders.stan(tags.div(render=tags.directive('liveElement')))
 
 
 
 class DynamicWidgetInstantiation(testcase.TestCase):
-    jsClass = u'Nevow.Athena.Tests.DynamicWidgetInstantiation'
+    jsClass = 'Nevow.Athena.Tests.DynamicWidgetInstantiation'
 
 
     def makeDynamicWidget(self):
@@ -413,10 +413,10 @@ class DynamicWidgetInstantiation(testcase.TestCase):
         """
         class DynamicFragment(athena.LiveFragment):
             docFactory = loaders.stan(tags.div(render=tags.directive('liveFragment')))
-            jsClass = u'Nevow.Athena.Tests.DynamicWidgetClass'
+            jsClass = 'Nevow.Athena.Tests.DynamicWidgetClass'
 
             def someMethod(self):
-                return u'foo'
+                return 'foo'
             expose(someMethod)
         return DynamicFragment()
 
@@ -440,10 +440,10 @@ class DynamicWidgetInstantiation(testcase.TestCase):
         """
         class DynamicFragment(athena.LiveFragment):
             docFactory = loaders.stan(tags.div(render=tags.directive('liveFragment')))
-            jsClass = u'Nevow.Athena.Tests.DynamicWidgetClass'
+            jsClass = 'Nevow.Athena.Tests.DynamicWidgetClass'
 
             def someMethod(self):
-                return u'foo'
+                return 'foo'
             expose(someMethod)
 
         f = DynamicFragment()
@@ -466,8 +466,8 @@ class DynamicWidgetInstantiation(testcase.TestCase):
         widgetInfo = f._structured()
 
         return {
-            u'id': widgetInfo[u'id'],
-            u'klass': widgetInfo[u'class']}
+            'id': widgetInfo['id'],
+            'klass': widgetInfo['class']}
     expose(getDynamicWidgetInfo)
 
 
@@ -517,7 +517,7 @@ class DynamicWidgetInstantiation(testcase.TestCase):
             docFactory = loaders.stan(
                 tags.div(render=tags.directive('liveFragment'))[
                     tags.div(render=tags.directive('child'))])
-            jsClass = u'Nevow.Athena.Tests.DynamicWidgetClass'
+            jsClass = 'Nevow.Athena.Tests.DynamicWidgetClass'
 
             def render_child(self, ctx):
                 childFragment.setFragmentParent(self)
@@ -547,12 +547,12 @@ class DynamicWidgetInstantiation(testcase.TestCase):
 
 
 class GettingWidgetlessNodeRaisesException(testcase.TestCase):
-    jsClass = u'Nevow.Athena.Tests.GettingWidgetlessNodeRaisesException'
+    jsClass = 'Nevow.Athena.Tests.GettingWidgetlessNodeRaisesException'
 
 
 
 class RemoteMethodErrorShowsDialog(testcase.TestCase):
-    jsClass = u'Nevow.Athena.Tests.RemoteMethodErrorShowsDialog'
+    jsClass = 'Nevow.Athena.Tests.RemoteMethodErrorShowsDialog'
 
     def raiseValueError(self):
         raise ValueError('hi')
@@ -564,7 +564,7 @@ class DelayedCallTests(testcase.TestCase):
     """
     Tests for the behavior of scheduling timed calls in the client.
     """
-    jsClass = u'Nevow.Athena.Tests.DelayedCallTests'
+    jsClass = 'Nevow.Athena.Tests.DelayedCallTests'
 
 
 
@@ -573,7 +573,7 @@ class DynamicStylesheetFetching(testcase.TestCase, CSSModuleTestMixin):
     Tests for stylesheet fetching when dynamic widget instantiation is
     involved.
     """
-    jsClass = u'Nevow.Athena.Tests.DynamicStylesheetFetching'
+    jsClass = 'Nevow.Athena.Tests.DynamicStylesheetFetching'
     # lala we want to use TestCase.mktemp
     _testMethodName = 'DynamicStylesheetFetching'
 
@@ -584,14 +584,14 @@ class DynamicStylesheetFetching(testcase.TestCase, CSSModuleTestMixin):
         self.page.cssModules = self._makeCSSRegistry()
 
         element = athena.LiveElement()
-        element.cssModule = u'TestCSSModuleDependencies.Dependor'
+        element.cssModule = 'TestCSSModuleDependencies.Dependor'
         element.setFragmentParent(self)
         element.docFactory = loaders.stan(
             tags.div(render=tags.directive('liveElement')))
 
         return (
             element,
-            [unicode(self.page.getCSSModuleURL(n))
+            [str(self.page.getCSSModuleURL(n))
                 for n in ('TestCSSModuleDependencies',
                           'TestCSSModuleDependencies.Dependee',
                           'TestCSSModuleDependencies.Dependor')])

--- a/nevow/test/livetest_athena.py
+++ b/nevow/test/livetest_athena.py
@@ -5,7 +5,7 @@
 Browser integration tests for Athena.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.internet import defer
 
@@ -167,12 +167,11 @@ class AsyncExceptionFromClient(testcase.TestCase):
         else:
             raise f
 
-
+@implementer(IAthenaTransportable)
 class CustomTransportable(object):
     """
     A simple transportable object used to verify customization is possible.
     """
-    implements(IAthenaTransportable)
 
     jsClass = 'Nevow.Athena.Tests.CustomTransportable'
 

--- a/nevow/test/livetest_runtime.py
+++ b/nevow/test/livetest_runtime.py
@@ -3,22 +3,22 @@ from nevow.livetrial import testcase
 
 
 class SetNodeContent(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.SetNodeContent'
+    jsClass = 'Divmod.Runtime.Tests.SetNodeContent'
 
 
 
 class AppendNodeContent(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.AppendNodeContent'
+    jsClass = 'Divmod.Runtime.Tests.AppendNodeContent'
 
 
 
 class AppendNodeContentScripts(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.AppendNodeContentScripts'
+    jsClass = 'Divmod.Runtime.Tests.AppendNodeContentScripts'
 
 
 
 class ElementSize(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.ElementSize'
+    jsClass = 'Divmod.Runtime.Tests.ElementSize'
 
 
     def getWidgetDocument(self):
@@ -33,7 +33,7 @@ class ElementSize(testcase.TestCase):
 
 
 class ElementsByTagNameShallow(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.ElementsByTagNameShallow'
+    jsClass = 'Divmod.Runtime.Tests.ElementsByTagNameShallow'
 
     def getWidgetDocument(self):
         """
@@ -46,12 +46,12 @@ class ElementsByTagNameShallow(testcase.TestCase):
 
 
 class PageSize(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.PageSize'
+    jsClass = 'Divmod.Runtime.Tests.PageSize'
 
 
 
 class TraversalOrdering(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.TraversalOrdering'
+    jsClass = 'Divmod.Runtime.Tests.TraversalOrdering'
 
     def getWidgetDocument(self):
         """
@@ -69,12 +69,12 @@ class TraversalOrdering(testcase.TestCase):
 
 
 class FindInRootNode(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.FindInRootNode'
+    jsClass = 'Divmod.Runtime.Tests.FindInRootNode'
 
 
 
 class Standalone(testcase.TestCase):
-    jsClass = u'Divmod.Runtime.Tests.Standalone'
+    jsClass = 'Divmod.Runtime.Tests.Standalone'
 
 
 
@@ -82,7 +82,7 @@ class ElementPosition(testcase.TestCase):
     """
     Tests for the element position-getting methods
     """
-    jsClass = u'Divmod.Runtime.Tests.ElementPosition'
+    jsClass = 'Divmod.Runtime.Tests.ElementPosition'
 
 
 
@@ -90,4 +90,4 @@ class LoadScript(testcase.TestCase):
     """
     Tests for C{Divmod.Runtime.Platform.loadScript}.
     """
-    jsClass = u'Divmod.Runtime.Tests.LoadScript'
+    jsClass = 'Divmod.Runtime.Tests.LoadScript'

--- a/nevow/test/test_accessors.py
+++ b/nevow/test/test_accessors.py
@@ -28,13 +28,13 @@ class TestBasics(Base):
     def test_dict_directive(self):
         d = directive('one')
         ctx = self.makeContext({'one': 1, 'two': 2})
-        self.assertEquals(1, convertToData(d, ctx))
+        self.assertEqual(1, convertToData(d, ctx))
         self.assertRaises(KeyError, convertToData, directive('asdfasdf'), ctx)
 
     def test_list_directive(self):
         d= directive('2')
         ctx = self.makeContext([0, 1, 42, 3, 4])
-        self.assertEquals(42, convertToData(d, ctx))
+        self.assertEqual(42, convertToData(d, ctx))
         self.assertRaises(IndexError, convertToData, directive('9999'), ctx)
         self.assertRaises(ValueError, convertToData, directive('HAHAHAHA'), ctx)
 
@@ -42,7 +42,7 @@ class TestBasics(Base):
         def foo(context, data):
             return 42
         ctx = self.makeContext()
-        self.assertEquals(42, convertToData(foo, ctx))
+        self.assertEqual(42, convertToData(foo, ctx))
         d = directive('this wont work')
         ctx2 = self.makeContext(foo)
         self.assertRaises(NoAccessor, convertToData, d, ctx2)
@@ -75,23 +75,23 @@ class TestThroughDirective(Base):
     def test_simple(self):
         d = directive('foo')
         ctx = self.makeContext()
-        self.assertEquals(thefoo, convertToData(d, ctx))
+        self.assertEqual(thefoo, convertToData(d, ctx))
 
     def test_dict_through_directive(self):
         d1, d2 = directive('dict'), directive('one')
         ctx = self.makeContext(d1)
-        self.assertEquals(1, convertToData(d2, ctx))
+        self.assertEqual(1, convertToData(d2, ctx))
 
     def test_list_through_directive(self):
         d1, d2 = directive('list'), directive('1')
         ctx = self.makeContext(d1)
-        self.assertEquals(99, convertToData(d2, ctx))
+        self.assertEqual(99, convertToData(d2, ctx))
 
     def test_roundAndRound(self):
         ctx = self.makeContext(
             directive('factory'), directive('0'), directive('factory')
         )
-        self.assertEquals(f, convertToData(directive('0'), ctx))
+        self.assertEqual(f, convertToData(directive('0'), ctx))
         
     def test_missing(self):
         self.assertRaises(rend.DataNotFoundError, self.makeContext, directive('missing'))
@@ -107,19 +107,19 @@ class TestPageData(Base):
         data = None
         ctx = context.WovenContext()
         ctx.remember(APage(data), inevow.IData)
-        self.assertEquals(data, convertToData(ctx.locate(inevow.IData), ctx))
-        self.assertEquals('foo', convertToData(directive('foo'), ctx))
+        self.assertEqual(data, convertToData(ctx.locate(inevow.IData), ctx))
+        self.assertEqual('foo', convertToData(directive('foo'), ctx))
 
     def test_2_dictOriginal(self):
         data = {'hello': 'world'}
         ctx = context.WovenContext()
         ctx.remember(APage(data), inevow.IData)
         # IGettable should return our dictionary
-        self.assertEquals(data, convertToData(ctx.locate(inevow.IData), ctx))
+        self.assertEqual(data, convertToData(ctx.locate(inevow.IData), ctx))
         # IContainer on the *Page*, not the dictionary, should work
-        self.assertEquals('foo', convertToData(directive('foo'), ctx))
+        self.assertEqual('foo', convertToData(directive('foo'), ctx))
         # IContainer on the Page should delegate to IContainer(self.original) if no data_ method
-        self.assertEquals('world', convertToData(directive('hello'), ctx))
+        self.assertEqual('world', convertToData(directive('hello'), ctx))
 
 
 

--- a/nevow/test/test_appserver.py
+++ b/nevow/test/test_appserver.py
@@ -5,7 +5,7 @@
 Tests for L{nevow.appserver}.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from io import StringIO
 from shlex import split
@@ -24,8 +24,8 @@ from nevow.context import RequestContext
 from nevow.rend import Page
 from nevow.testutil import FakeRequest
 
+@implementer(inevow.IResource)
 class Render:
-    implements(inevow.IResource)
 
     rendered = False
 
@@ -81,8 +81,8 @@ class TestLookup(testutil.TestCase):
             lambda result: self.assertIdentical(r, result.tag))
 
     def test_cycle(self):
+        @implementer(inevow.IResource)
         class Resource(object):
-            implements(inevow.IResource)
             def locateChild(self, ctx, segments):
                 if segments[0] == 'self':
                     return self, segments

--- a/nevow/test/test_appserver.py
+++ b/nevow/test/test_appserver.py
@@ -7,7 +7,7 @@ Tests for L{nevow.appserver}.
 
 from zope.interface import implements
 
-from cStringIO import StringIO
+from io import StringIO
 from shlex import split
 
 from twisted.trial.unittest import TestCase
@@ -111,7 +111,7 @@ class TestSiteAndRequest(testutil.TestCase):
                 return util.succeed("hello")
 
         return self.renderResource(Deferreder(), 'foo').addCallback(
-            lambda result: self.assertEquals(result, "hello"))
+            lambda result: self.assertEqual(result, "hello"))
 
     def test_regularRender(self):
         class Regular(Render):
@@ -119,7 +119,7 @@ class TestSiteAndRequest(testutil.TestCase):
                 return "world"
 
         return self.renderResource(Regular(), 'bar').addCallback(
-            lambda result: self.assertEquals(result, 'world'))
+            lambda result: self.assertEqual(result, 'world'))
 
     def test_returnsResource(self):
         class Res2(Render):
@@ -131,7 +131,7 @@ class TestSiteAndRequest(testutil.TestCase):
                 return Res2()
 
         return self.renderResource(Res1(), 'bar').addCallback(
-            lambda result: self.assertEquals(result, 'world'))
+            lambda result: self.assertEqual(result, 'world'))
 
     def test_connectionLost(self):
         """
@@ -207,7 +207,7 @@ class Logging(testutil.TestCase):
         self.setSiteTime('faketime')
         proto = self.renderResource('/foo')
         logLines = proto.site.logFile.getvalue().splitlines()
-        self.assertEquals(len(logLines), 1)
+        self.assertEqual(len(logLines), 1)
         self.assertEqual(
             split(logLines[0]),
             ['fakeaddress2', '-', '-', 'faketime', 'GET /foo HTTP/1.0', '200', '6',
@@ -231,8 +231,8 @@ class Logging(testutil.TestCase):
         self.site.remember(myLog, inevow.ILogger)
         proto = self.renderResource('/foo')
         logLines = proto.site.logFile.getvalue().splitlines()
-        self.assertEquals(len(logLines), 0)
-        self.assertEquals(myLog.logged,
+        self.assertEqual(len(logLines), 0)
+        self.assertEqual(myLog.logged,
                           [
             ('fakeLog', 'fakeaddress2', 'GET', '/foo', 'HTTP/1.0', 200, 6),
             ])

--- a/nevow/test/test_athena.py
+++ b/nevow/test/test_athena.py
@@ -1,6 +1,6 @@
 
 import os, sets
-from itertools import izip
+
 from xml.dom.minidom import parseString
 
 from twisted.trial import unittest
@@ -35,7 +35,7 @@ class MappingResourceTests(unittest.TestCase):
         L{athena.MappingResource} isn't directly renderable.
         """
         m = athena.MappingResource({})
-        self.failUnless(isinstance(m.renderHTTP(None), rend.FourOhFour))
+        self.assertTrue(isinstance(m.renderHTTP(None), rend.FourOhFour))
 
 
     def test_lookupNonExistentKey(self):
@@ -44,7 +44,7 @@ class MappingResourceTests(unittest.TestCase):
         for a non-existent key.
         """
         m = athena.MappingResource({'name': 'value'})
-        self.assertEquals(m.locateChild(None, ('key',)), rend.NotFound)
+        self.assertEqual(m.locateChild(None, ('key',)), rend.NotFound)
 
 
     def test_lookupKey(self):
@@ -55,8 +55,8 @@ class MappingResourceTests(unittest.TestCase):
         m = athena.MappingResource({'name': 'value'})
         m.resourceFactory = sets.Set
         resource, segments = m.locateChild(None, ('name',))
-        self.assertEquals(segments, [])
-        self.assertEquals(resource, sets.Set('value'))
+        self.assertEqual(segments, [])
+        self.assertEqual(resource, sets.Set('value'))
 
 
 
@@ -68,7 +68,7 @@ class ModuleRegistryTestMixin:
         """
         C{getModuleForName} should return the right kind of module.
         """
-        moduleName = u'test_getModuleForName'
+        moduleName = 'test_getModuleForName'
         mapping = {moduleName: self.mktemp()}
         reg = self.registryClass(mapping)
         mod = reg.getModuleForName(moduleName)
@@ -82,7 +82,7 @@ class ModuleRegistryTestMixin:
         C{getModuleForName} should get angry if we ask for a module which
         doesn't exist.
         """
-        moduleName = u'test_getModuleForName'
+        moduleName = 'test_getModuleForName'
         reg = self.registryClass({})
         self.assertRaises(
             RuntimeError,
@@ -104,7 +104,7 @@ class CSSRegistryTests(unittest.TestCase, ModuleRegistryTestMixin):
         L{athena.CSSRegistry} should initialize its mapping from
         L{athena.allCSSPackages} as needed.
         """
-        moduleName = u'test_getModuleForNameLoad'
+        moduleName = 'test_getModuleForNameLoad'
         origAllCSSPackages = athena.allCSSPackages
         theCSSPackages = {moduleName: self.mktemp()}
         athena.allCSSPackages = lambda: theCSSPackages
@@ -131,7 +131,7 @@ class JSDependenciesTests(unittest.TestCase, ModuleRegistryTestMixin):
         L{athena.JSDependencies} should initialize its mapping from
         L{athena.allCSSPackages} as needed.
         """
-        moduleName = u'test_getModuleForNameLoad'
+        moduleName = 'test_getModuleForNameLoad'
         origAllJavascriptPackages = athena.allJavascriptPackages
         theJavascriptPackages = {moduleName: self.mktemp()}
         athena.allJavascriptPackages = lambda: theJavascriptPackages
@@ -180,7 +180,7 @@ the end
         m2 = self.moduleClass.getOrCreate('testmodule', modules)
 
         self.assertTrue(isinstance(m1, self.moduleClass))
-        self.assertEquals(m1.name, 'testmodule')
+        self.assertEqual(m1.name, 'testmodule')
 
         self.assertIdentical(m1, m2)
 
@@ -219,7 +219,7 @@ the end
         m = self.moduleClass.getOrCreate('testmodule', modules)
         deps = [d.name for d in m.dependencies()]
         deps.sort()
-        self.assertEquals(deps, ['Another', 'ExampleModule', 'Module'])
+        self.assertEqual(deps, ['Another', 'ExampleModule', 'Module'])
 
 
     def test_allDependencies(self):
@@ -246,7 +246,7 @@ the end
                 # that depends upon them.
                 self.assertIn(d, allDeps)
                 self.assertIn(depMod, allDeps)
-                self.failUnless(allDeps.index(d) < allDeps.index(depMod))
+                self.assertTrue(allDeps.index(d) < allDeps.index(depMod))
 
 
     def test_crlfNewlines(self):
@@ -268,7 +268,7 @@ the end
         module = self.moduleClass('Foo', modules)
         fooDependencies = list(module.dependencies())
         self.assertEqual(len(fooDependencies), 1)
-        self.assertEqual(fooDependencies[0].name, u'Bar')
+        self.assertEqual(fooDependencies[0].name, 'Bar')
 
 
     def test_dependencyCaching(self):
@@ -290,15 +290,15 @@ the end
         m._extractImports = _extractImports
 
         list(m.dependencies())
-        self.assertEquals(m.extractCounter, 1)
+        self.assertEqual(m.extractCounter, 1)
 
         list(m.dependencies())
-        self.assertEquals(m.extractCounter, 1)
+        self.assertEqual(m.extractCounter, 1)
 
         newTime = m.lastModified
         os.utime(testModuleFilename, (newTime + 1, newTime + 1))
         list(m.dependencies())
-        self.assertEquals(m.extractCounter, 2)
+        self.assertEqual(m.extractCounter, 2)
 
 
     def test_packageDependencies(self):
@@ -306,11 +306,11 @@ the end
         L{athena.AthenaModule} should include a module's package in its
         dependencies.
         """
-        modules = {u'Foo': self.mktemp(), u'Foo.Bar': self.mktemp()}
-        file(modules[u'Foo'], 'wb').close()
-        file(modules[u'Foo.Bar'], 'wb').close()
-        foo = self.moduleClass.getOrCreate(u'Foo', modules)
-        bar = self.moduleClass.getOrCreate(u'Foo.Bar', modules)
+        modules = {'Foo': self.mktemp(), 'Foo.Bar': self.mktemp()}
+        file(modules['Foo'], 'wb').close()
+        file(modules['Foo.Bar'], 'wb').close()
+        foo = self.moduleClass.getOrCreate('Foo', modules)
+        bar = self.moduleClass.getOrCreate('Foo.Bar', modules)
         self.assertIn(foo, bar.allDependencies())
 
 
@@ -318,7 +318,7 @@ the end
         """
         L{athena.AthenaModule} should C{repr} to something helpful.
         """
-        moduleName = u'Foo.Bar'
+        moduleName = 'Foo.Bar'
         module = self.moduleClass(
             moduleName, {moduleName: self.mktemp()})
         self.assertEqual(
@@ -445,11 +445,11 @@ class ModuleInteractionTests(unittest.TestCase):
         namespaces.
         """
         cssModule = athena.CSSModule.getOrCreate(
-            u'test_separateModuleNamespace',
-            {u'test_separateModuleNamespace': self.mktemp()})
+            'test_separateModuleNamespace',
+            {'test_separateModuleNamespace': self.mktemp()})
         jsModule = athena.JSModule.getOrCreate(
-            u'test_separateModuleNamespace',
-            {u'test_separateModuleNamespace': self.mktemp()})
+            'test_separateModuleNamespace',
+            {'test_separateModuleNamespace': self.mktemp()})
         self.assertNotIdentical(cssModule, jsModule)
         self.assertTrue(isinstance(cssModule, athena.CSSModule))
         self.assertTrue(isinstance(jsModule, athena.JSModule))
@@ -477,10 +477,10 @@ class _AutoPackageTestMixin:
             return path
 
         expected = {
-            u'Foo': childPath('Foo', '__init__.' + self.moduleExtension),
-            u'Foo.Bar': childPath('Foo', 'Bar.' + self.moduleExtension),
-            u'Foo.Baz': util.sibpath(athena.__file__, 'empty-module.' + self.moduleExtension),
-            u'Foo.Baz.Quux': childPath('Foo', 'Baz', 'Quux.' + self.moduleExtension)}
+            'Foo': childPath('Foo', '__init__.' + self.moduleExtension),
+            'Foo.Bar': childPath('Foo', 'Bar.' + self.moduleExtension),
+            'Foo.Baz': util.sibpath(athena.__file__, 'empty-module.' + self.moduleExtension),
+            'Foo.Baz.Quux': childPath('Foo', 'Baz', 'Quux.' + self.moduleExtension)}
 
         childPath('Foo', '.foo.' + self.moduleExtension)
         os.mkdir(os.path.join(packageDir, 'Foo', '.test'))
@@ -489,10 +489,10 @@ class _AutoPackageTestMixin:
         childPath('Foo', 'Zot.other')
 
         package = self.packageFactory(packageDir)
-        for module, path in expected.iteritems():
+        for module, path in expected.items():
             m = package.mapping.pop(module)
-            self.assertEquals(m, path)
-        self.assertEquals(package.mapping, {})
+            self.assertEqual(m, path)
+        self.assertEqual(package.mapping, {})
 
 
 
@@ -558,7 +558,7 @@ class UtilitiesTests(unittest.TestCase):
         tag = tags.span[athena.handler(event='onclick', handler='bar')]
         mutated = athena._rewriteEventHandlerToAttribute(tag)
         output = flat.flatten(mutated)
-        self.assertEquals(
+        self.assertEqual(
             output,
             '<span onclick="' + expectedOutput + '"></span>')
 
@@ -569,7 +569,7 @@ class UtilitiesTests(unittest.TestCase):
         macro is.
         """
         tag = ["hello", " ", "world"]
-        self.assertEquals(
+        self.assertEqual(
             athena._rewriteEventHandlerToAttribute(tag),
             tag)
 
@@ -618,7 +618,7 @@ class UtilitiesTests(unittest.TestCase):
         renderDeferred = renderPage(page)
         def rendered(result):
             page.action_close(None)
-            self.assertEquals(preprocessed, [[tag]])
+            self.assertEqual(preprocessed, [[tag]])
         renderDeferred.addCallback(rendered)
         return renderDeferred
 
@@ -681,7 +681,7 @@ class StandardLibraryTestCase(unittest.TestCase):
     def _importTest(self, moduleName):
         mod = self.deps.getModuleForName(moduleName)
         inspect = [dep for dep in mod.allDependencies() if dep.name == moduleName]
-        self.failUnless(inspect)
+        self.assertTrue(inspect)
 
 
     def test_divmodImport(self):
@@ -775,14 +775,14 @@ class Nesting(unittest.TestCase):
         tf1.setFragmentParent(lp)
         tf2.setFragmentParent(tf1)
 
-        self.assertEquals(lp.liveFragmentChildren, [tf1])
-        self.assertEquals(tf1.liveFragmentChildren, [tf2])
-        self.assertEquals(tf2.liveFragmentChildren, [])
-        self.assertEquals(tf2.fragmentParent, tf1)
-        self.assertEquals(tf1.fragmentParent, lp)
+        self.assertEqual(lp.liveFragmentChildren, [tf1])
+        self.assertEqual(tf1.liveFragmentChildren, [tf2])
+        self.assertEqual(tf2.liveFragmentChildren, [])
+        self.assertEqual(tf2.fragmentParent, tf1)
+        self.assertEqual(tf1.fragmentParent, lp)
 
-        self.assertEquals(tf2.page, lp)
-        self.assertEquals(tf1.page, lp)
+        self.assertEqual(tf2.page, lp)
+        self.assertEqual(tf1.page, lp)
 
 
     def testInsideOutFragmentNesting(self):
@@ -797,13 +797,13 @@ class Nesting(unittest.TestCase):
         innerFragment.setFragmentParent(outerFragment)
         outerFragment.setFragmentParent(page)
 
-        self.assertEquals(page.liveFragmentChildren, [outerFragment])
-        self.assertEquals(outerFragment.fragmentParent, page)
-        self.assertEquals(outerFragment.page, page)
+        self.assertEqual(page.liveFragmentChildren, [outerFragment])
+        self.assertEqual(outerFragment.fragmentParent, page)
+        self.assertEqual(outerFragment.page, page)
 
-        self.assertEquals(outerFragment.liveFragmentChildren, [innerFragment])
-        self.assertEquals(innerFragment.fragmentParent, outerFragment)
-        self.assertEquals(innerFragment.page, page)
+        self.assertEqual(outerFragment.liveFragmentChildren, [innerFragment])
+        self.assertEqual(innerFragment.fragmentParent, outerFragment)
+        self.assertEqual(innerFragment.page, page)
 
 
 
@@ -814,14 +814,14 @@ class Tracebacks(unittest.TestCase):
 
     stack = '\n'.join(['%s@%s:%d' % frame for frame in frames])
 
-    exc = {u'name': 'SomeError',
-           u'message': 'An error occurred.',
-           u'stack': stack}
+    exc = {'name': 'SomeError',
+           'message': 'An error occurred.',
+           'stack': stack}
 
     def testStackParsing(self):
         p = athena.parseStack(self.stack)
-        for iframe, oframe in izip(self.frames[::-1], p):
-            self.assertEquals(oframe, iframe)
+        for iframe, oframe in zip(self.frames[::-1], p):
+            self.assertEqual(oframe, iframe)
 
     def testStackLengthAndOrder(self):
         f = athena.getJSFailure(self.exc, {})
@@ -840,7 +840,8 @@ class _DelayedCall(object):
 
 
 def mappend(transport):
-    def send((ack, messages)):
+    def send(xxx_todo_changeme):
+        (ack, messages) = xxx_todo_changeme
         transport.append(messages[:])
     return send
 
@@ -898,9 +899,9 @@ class Transport(unittest.TestCase):
         """
         self.rdm.addOutput(mappend(self.transport))
         self.rdm.addMessage(self.theMessage)
-        self.assertEquals(self.transport, [[(0, self.theMessage)]])
+        self.assertEqual(self.transport, [[(0, self.theMessage)]])
         self.rdm.addMessage(self.theMessage)
-        self.assertEquals(self.transport, [[(0, self.theMessage)]])
+        self.assertEqual(self.transport, [[(0, self.theMessage)]])
 
 
     def testSendMessageQueued(self):
@@ -910,7 +911,7 @@ class Transport(unittest.TestCase):
         """
         self.rdm.addMessage(self.theMessage)
         self.rdm.addOutput(mappend(self.transport))
-        self.assertEquals(self.transport, [[(0, self.theMessage)]])
+        self.assertEqual(self.transport, [[(0, self.theMessage)]])
 
 
     def testMultipleQueuedMessages(self):
@@ -921,7 +922,7 @@ class Transport(unittest.TestCase):
         self.rdm.addMessage(self.theMessage)
         self.rdm.addMessage(self.theMessage.encode('hex'))
         self.rdm.addOutput(mappend(self.transport))
-        self.assertEquals(self.transport, [[(0, self.theMessage), (1, self.theMessage.encode('hex'))]])
+        self.assertEqual(self.transport, [[(0, self.theMessage), (1, self.theMessage.encode('hex'))]])
 
 
     def testMultipleQueuedOutputs(self):
@@ -933,8 +934,8 @@ class Transport(unittest.TestCase):
         self.rdm.addOutput(mappend(self.transport))
         self.rdm.addOutput(mappend(secondTransport))
         self.rdm.addMessage(self.theMessage)
-        self.assertEquals(self.transport, [[(0, self.theMessage)]])
-        self.assertEquals(secondTransport, [])
+        self.assertEqual(self.transport, [[(0, self.theMessage)]])
+        self.assertEqual(secondTransport, [])
 
 
     def testMessageRedelivery(self):
@@ -949,15 +950,15 @@ class Transport(unittest.TestCase):
         self.rdm.addMessage(self.theMessage)
         self.rdm.addMessage(secondMessage)
         self.rdm.addOutput(mappend(self.transport))
-        self.assertEquals(self.transport, [[(0, self.theMessage), (1, secondMessage)]])
+        self.assertEqual(self.transport, [[(0, self.theMessage), (1, secondMessage)]])
         self.rdm.addOutput(mappend(secondTransport))
-        self.assertEquals(secondTransport, [[(0, self.theMessage), (1, secondMessage)]])
+        self.assertEqual(secondTransport, [[(0, self.theMessage), (1, secondMessage)]])
         self.rdm.basketCaseReceived(None, [0, []])
         self.rdm.addOutput(mappend(thirdTransport))
-        self.assertEquals(thirdTransport, [[(1, secondMessage)]])
+        self.assertEqual(thirdTransport, [[(1, secondMessage)]])
         self.rdm.basketCaseReceived(None, [1, []])
         self.rdm.addOutput(mappend(fourthTransport))
-        self.assertEquals(fourthTransport, [])
+        self.assertEqual(fourthTransport, [])
 
 
     def testConnectTimeout(self):
@@ -967,15 +968,15 @@ class Transport(unittest.TestCase):
         established.
         """
         n, f, a, kw = self.scheduled.pop()
-        self.failIf(self.scheduled, "Too many tasks scheduled.")
+        self.assertFalse(self.scheduled, "Too many tasks scheduled.")
 
-        self.assertEquals(n, self.connectTimeout)
+        self.assertEqual(n, self.connectTimeout)
         f(*a, **kw)
 
-        self.assertEquals(len(self.events), 1)
+        self.assertEqual(len(self.events), 1)
         self.events[0].trap(athena.ConnectFailed)
 
-        self.failIf(self.scheduled, "Unexpected task scheduled after connect failed.")
+        self.assertFalse(self.scheduled, "Unexpected task scheduled after connect failed.")
 
 
     def testConnectSucceeds(self):
@@ -983,12 +984,12 @@ class Transport(unittest.TestCase):
         Test that the connection timeout is cancelled when an output channel is
         added.
         """
-        self.failUnless(self.scheduled, "No connect timeout scheduled.") # Sanity check
+        self.assertTrue(self.scheduled, "No connect timeout scheduled.") # Sanity check
         self.rdm.addOutput(mappend(self.transport))
         n, f, a, kw = self.scheduled.pop()
-        self.assertEquals(n, self.idleTimeout)
-        self.failIf(self.scheduled, "Output channel added but there is still a task pending.")
-        self.assertEquals(self.transport, [], "Received unexpected output.")
+        self.assertEqual(n, self.idleTimeout)
+        self.assertFalse(self.scheduled, "Output channel added but there is still a task pending.")
+        self.assertEqual(self.transport, [], "Received unexpected output.")
 
 
     def test_connectionMade(self):
@@ -1014,15 +1015,15 @@ class Transport(unittest.TestCase):
         self.rdm.addOutput(mappend(self.transport))
 
         n, f, a, kw = self.scheduled.pop()
-        self.failIf(self.scheduled, "Too many tasks scheduled.")
+        self.assertFalse(self.scheduled, "Too many tasks scheduled.")
 
-        self.assertEquals(n, self.transportlessTimeout)
+        self.assertEqual(n, self.transportlessTimeout)
         f(*a, **kw)
 
-        self.assertEquals(len(self.events), 1)
+        self.assertEqual(len(self.events), 1)
         self.events[0].trap(athena.ConnectionLost)
 
-        self.failIf(self.scheduled, "Unexpected task scheduled after connection lost.")
+        self.assertFalse(self.scheduled, "Unexpected task scheduled after connection lost.")
 
 
     def testMessageConsumedOutputTimeout(self):
@@ -1035,15 +1036,15 @@ class Transport(unittest.TestCase):
         self.rdm.addMessage(self.theMessage)
 
         n, f, a, kw = self.scheduled.pop()
-        self.failIf(self.scheduled, "Too many tasks scheduled.")
+        self.assertFalse(self.scheduled, "Too many tasks scheduled.")
 
-        self.assertEquals(n, self.transportlessTimeout)
+        self.assertEqual(n, self.transportlessTimeout)
         f(*a, **kw)
 
-        self.assertEquals(len(self.events), 1)
+        self.assertEqual(len(self.events), 1)
         self.events[0].trap(athena.ConnectionLost)
 
-        self.failIf(self.scheduled, "Unexpected task scheduled after connection lost.")
+        self.assertFalse(self.scheduled, "Unexpected task scheduled after connection lost.")
 
 
     def testOutputConnectionAdded(self):
@@ -1054,17 +1055,17 @@ class Transport(unittest.TestCase):
         self.rdm.addMessage(self.theMessage)
         self.rdm.addOutput(mappend(self.transport))
 
-        self.assertEquals(len(self.scheduled), 1, "Transportless timeout not created.")
+        self.assertEqual(len(self.scheduled), 1, "Transportless timeout not created.")
         n, f, a, kw = self.scheduled[0]
-        self.assertEquals(n, self.transportlessTimeout, "Unexpected task still scheduled after output added.")
+        self.assertEqual(n, self.transportlessTimeout, "Unexpected task still scheduled after output added.")
 
         self.rdm.basketCaseReceived(None, [0, []])
 
         n, f, a, kw = self.scheduled.pop()
-        self.assertEquals(n, self.idleTimeout)
+        self.assertEqual(n, self.idleTimeout)
 
-        self.failIf(self.scheduled, "Unexpected task still scheduled after output added.")
-        self.failIf(self.events, "Unexpectedly received some kind of event.")
+        self.assertFalse(self.scheduled, "Unexpected task still scheduled after output added.")
+        self.assertFalse(self.events, "Unexpectedly received some kind of event.")
 
 
     def testIdleOutputTimeout(self):
@@ -1075,12 +1076,12 @@ class Transport(unittest.TestCase):
         self.rdm.addOutput(mappend(self.transport))
 
         n, f, a, kw = self.scheduled.pop()
-        self.assertEquals(n, self.idleTimeout)
-        self.failIf(self.scheduled, "Unexpected tasks still scheduled in addition to idle timeout task.")
+        self.assertEqual(n, self.idleTimeout)
+        self.assertFalse(self.scheduled, "Unexpected tasks still scheduled in addition to idle timeout task.")
 
         f(*a, **kw)
 
-        self.assertEquals(self.transport, [[]])
+        self.assertEqual(self.transport, [[]])
 
 
     def testIdleTimeoutStartsOutputlessTimeout(self):
@@ -1091,16 +1092,16 @@ class Transport(unittest.TestCase):
         self.rdm.addOutput(mappend(self.transport))
 
         n, f, a, kw = self.scheduled.pop()
-        self.assertEquals(n, self.idleTimeout)
+        self.assertEqual(n, self.idleTimeout)
         f(*a, **kw)
 
-        self.failIf(self.events, "Unexpectedly received some events.")
+        self.assertFalse(self.events, "Unexpectedly received some events.")
 
         n, f, a, kw = self.scheduled.pop()
-        self.assertEquals(n, self.transportlessTimeout)
+        self.assertEqual(n, self.transportlessTimeout)
         f(*a, **kw)
 
-        self.assertEquals(len(self.events), 1)
+        self.assertEqual(len(self.events), 1)
         self.events[0].trap(athena.ConnectionLost)
 
 
@@ -1114,15 +1115,15 @@ class Transport(unittest.TestCase):
 
         # The connection timeout should have been cancelled and
         # replaced with an idle timeout.
-        self.assertEquals(len(self.scheduled), 1)
+        self.assertEqual(len(self.scheduled), 1)
         n, f, a, kw = self.scheduled[0]
-        self.assertEquals(n, self.idleTimeout)
+        self.assertEqual(n, self.idleTimeout)
 
         self.rdm.addMessage(self.theMessage)
-        self.assertEquals(self.transport, [])
+        self.assertEqual(self.transport, [])
 
         self.rdm.unpause()
-        self.assertEquals(self.transport, [[(0, self.theMessage)]])
+        self.assertEqual(self.transport, [[(0, self.theMessage)]])
 
 
     def testTransportlessPause(self):
@@ -1135,10 +1136,10 @@ class Transport(unittest.TestCase):
 
         self.rdm.pause()
         self.rdm.addMessage(self.theMessage)
-        self.assertEquals(self.transport, [])
+        self.assertEqual(self.transport, [])
 
         self.rdm.unpause()
-        self.assertEquals(self.transport, [[(0, self.theMessage)]])
+        self.assertEqual(self.transport, [[(0, self.theMessage)]])
 
 
     def testMessagelessPause(self):
@@ -1151,10 +1152,10 @@ class Transport(unittest.TestCase):
 
         self.rdm.pause()
         self.rdm.addMessage(self.theMessage)
-        self.assertEquals(self.transport, [])
+        self.assertEqual(self.transport, [])
 
         self.rdm.unpause()
-        self.assertEquals(self.transport, [[(0, self.theMessage)]])
+        self.assertEqual(self.transport, [[(0, self.theMessage)]])
 
 
     def testStaleMessages(self):
@@ -1168,7 +1169,7 @@ class Transport(unittest.TestCase):
             [-1, [[0, self.theMessage],
                   [1, self.theMessage + "-1"],
                   [2, self.theMessage + "-2"]]])
-        self.assertEquals(
+        self.assertEqual(
             self.outgoingMessages,
             [(None, self.theMessage),
              (None, self.theMessage + "-1"),
@@ -1178,14 +1179,14 @@ class Transport(unittest.TestCase):
         self.rdm.basketCaseReceived(
             None,
             [-1, [[1, self.theMessage + "-1"]]])
-        self.assertEquals(
+        self.assertEqual(
             self.outgoingMessages,
             [])
 
         self.rdm.basketCaseReceived(
             None,
             [-1, [[2, self.theMessage + "-2"]]])
-        self.assertEquals(
+        self.assertEqual(
             self.outgoingMessages,
             [])
 
@@ -1200,11 +1201,11 @@ class Transport(unittest.TestCase):
         self.rdm.addOutput(mappend(self.transport))
         self.rdm.addOutput(mappend(self.transport))
         self.rdm.close()
-        self.assertEquals(self.transport, [[(0, (athena.CLOSE, []))], [(0, (athena.CLOSE, []))]])
+        self.assertEqual(self.transport, [[(0, (athena.CLOSE, []))], [(0, (athena.CLOSE, []))]])
 
         self.transport = []
         self.rdm.addOutput(mappend(self.transport))
-        self.assertEquals(self.transport, [[(0, (athena.CLOSE, []))]])
+        self.assertEqual(self.transport, [[(0, (athena.CLOSE, []))]])
 
 
     def testCloseBeforeConnect(self):
@@ -1213,7 +1214,7 @@ class Transport(unittest.TestCase):
         ever established properly cleans up any timeouts.
         """
         self.rdm.close()
-        self.failIf(self.scheduled, "Expected no scheduled calls.")
+        self.assertFalse(self.scheduled, "Expected no scheduled calls.")
 
 
     def test_closeExcessOnReceived(self):
@@ -1224,9 +1225,9 @@ class Transport(unittest.TestCase):
         self.rdm.addOutput(mappend(self.transport))
         self.rdm.addOutput(mappend(secondTransport))
         d = self.rdm.basketCaseReceived(None, [0, []])
-        self.assertEquals(self.transport, [[]])
-        self.assertEquals(secondTransport, [[]])
-        self.failIf(d.called)
+        self.assertEqual(self.transport, [[]])
+        self.assertEqual(secondTransport, [[]])
+        self.assertFalse(d.called)
 
 
     def test_closeExcessOnUnpaused(self):
@@ -1459,7 +1460,7 @@ class LiveMixinTestsMixin(CSSModuleTestMixin):
         Our element's glue should include inline stylesheet references.
         """
         element = self.elementFactory()
-        element.cssModule = u'TestCSSModuleDependencies.Dependor'
+        element.cssModule = 'TestCSSModuleDependencies.Dependor'
         element.docFactory = loaders.stan(
             tags.div(render=tags.directive(self.liveGlueRenderer)))
 
@@ -1470,8 +1471,8 @@ class LiveMixinTestsMixin(CSSModuleTestMixin):
         def cbRendered(result):
             expected = flat.flatten(
                 page.getStylesheetStan(
-                    [page.getCSSModuleURL(u'TestCSSModuleDependencies.Dependee'),
-                     page.getCSSModuleURL(u'TestCSSModuleDependencies.Dependor')]))
+                    [page.getCSSModuleURL('TestCSSModuleDependencies.Dependee'),
+                     page.getCSSModuleURL('TestCSSModuleDependencies.Dependor')]))
             self.assertIn(expected, result)
         D.addCallback(cbRendered)
         return D
@@ -1482,7 +1483,7 @@ class LiveMixinTestsMixin(CSSModuleTestMixin):
         Our element's glue shouldn't include redundant stylesheet references.
         """
         element = self.elementFactory()
-        element.cssModule = u'TestCSSModuleDependencies.Dependor'
+        element.cssModule = 'TestCSSModuleDependencies.Dependor'
         element.docFactory = loaders.stan(
             tags.div(render=tags.directive(self.liveGlueRenderer)))
 
@@ -1497,8 +1498,8 @@ class LiveMixinTestsMixin(CSSModuleTestMixin):
         def cbRendered(result):
             expected = flat.flatten(
                 page.getStylesheetStan(
-                    [page.getCSSModuleURL(u'TestCSSModuleDependencies.Dependee'),
-                     page.getCSSModuleURL(u'TestCSSModuleDependencies.Dependor')]))
+                    [page.getCSSModuleURL('TestCSSModuleDependencies.Dependee'),
+                     page.getCSSModuleURL('TestCSSModuleDependencies.Dependor')]))
             self.assertIn(expected, result)
         D.addCallback(cbRendered)
         return D
@@ -1567,7 +1568,7 @@ class LivePageTests(unittest.TestCase, CSSModuleTestMixin):
         calling a single JavaScript function.
         """
         bc = self.page._bootstrapCall(
-            "SomeModule.someMethod", [u"one", 2, {u"three": 4.1}])
+            "SomeModule.someMethod", ["one", 2, {"three": 4.1}])
         self.assertEqual(
             bc, 'SomeModule.someMethod("one", 2, {"three":4.1});')
 
@@ -1577,14 +1578,14 @@ class LivePageTests(unittest.TestCase, CSSModuleTestMixin):
         L{LivePage.render_liveglue} should include modules that the
         L{LivePage}'s jsClass depends on.
         """
-        self.page.jsClass = u'PythonTestSupport.Dependor.PageTest'
+        self.page.jsClass = 'PythonTestSupport.Dependor.PageTest'
         freq = FakeRequest()
         self.page._becomeLive(url.URL.fromRequest(freq))
         ctx = WovenContext(tag=tags.div())
         ctx.remember(freq, IRequest)
         self.assertEqual(self.page.render_liveglue(ctx, None), ctx.tag)
-        expectDependor = flat.flatten(self.page.getImportStan(u'PythonTestSupport.Dependor'))
-        expectDependee = flat.flatten(self.page.getImportStan(u'PythonTestSupport.Dependee'))
+        expectDependor = flat.flatten(self.page.getImportStan('PythonTestSupport.Dependor'))
+        expectDependee = flat.flatten(self.page.getImportStan('PythonTestSupport.Dependee'))
         result = flat.flatten(ctx.tag, ctx)
         self.assertIn(expectDependor, result)
         self.assertIn(expectDependee, result)
@@ -1595,7 +1596,7 @@ class LivePageTests(unittest.TestCase, CSSModuleTestMixin):
         L{athena.LivePage.render_liveglue} should include CSS modules that
         the top-level C{cssModule} depends on.
         """
-        self.page.cssModule = u'TestCSSModuleDependencies.Dependor'
+        self.page.cssModule = 'TestCSSModuleDependencies.Dependor'
         self.page.cssModules = self._makeCSSRegistry()
 
         self.page._becomeLive(url.URL())
@@ -1604,8 +1605,8 @@ class LivePageTests(unittest.TestCase, CSSModuleTestMixin):
         self.assertEqual(self.page.render_liveglue(ctx, None), ctx.tag)
         expected = flat.flatten(
             self.page.getStylesheetStan(
-                [self.page.getCSSModuleURL(u'TestCSSModuleDependencies.Dependee'),
-                 self.page.getCSSModuleURL(u'TestCSSModuleDependencies.Dependor')]))
+                [self.page.getCSSModuleURL('TestCSSModuleDependencies.Dependee'),
+                 self.page.getCSSModuleURL('TestCSSModuleDependencies.Dependor')]))
         self.assertIn(expected, flat.flatten(ctx.tag, ctx))
 
 
@@ -1629,9 +1630,9 @@ class LivePageTests(unittest.TestCase, CSSModuleTestMixin):
               # Nevow's URL quoting rules are weird, but this is the URL
               # flattener's fault, not mine.  Adjust to taste if that changes
               # (it won't) -glyph
-              [u"http://localhost/'%22"]),
+              ["http://localhost/'%22"]),
              ("Nevow.Athena.bootstrap",
-              [u'Nevow.Athena.PageWidget', u'asdf'])])
+              ['Nevow.Athena.PageWidget', 'asdf'])])
 
 
     def test_renderReconnect(self):
@@ -1681,7 +1682,7 @@ class LivePageTests(unittest.TestCase, CSSModuleTestMixin):
         page = athena.LivePage(
             cssModuleRoot=theCSSModuleRoot)
         self.assertEqual(
-            page.getCSSModuleURL(u'X.Y'),
+            page.getCSSModuleURL('X.Y'),
             theCSSModuleRoot.child('X.Y'))
 
 
@@ -1855,7 +1856,7 @@ class WidgetSubcommandTests(unittest.TestCase):
         """
         options = widgetServiceMaker.options()
         options.parseOptions(['--element', qual(DummyLiveElement)])
-        self.assertEquals(options['element'], DummyLiveElement)
+        self.assertEqual(options['element'], DummyLiveElement)
 
 
     def test_invalidWidgetOption(self):
@@ -1895,8 +1896,8 @@ class WidgetSubcommandTests(unittest.TestCase):
         Verify that the necessary interfaces for the object to be found as a
         twistd subcommand plugin are provided.
         """
-        self.failUnless(IPlugin.providedBy(widgetServiceMaker))
-        self.failUnless(IServiceMaker.providedBy(widgetServiceMaker))
+        self.assertTrue(IPlugin.providedBy(widgetServiceMaker))
+        self.assertTrue(IServiceMaker.providedBy(widgetServiceMaker))
 
 
     def test_makeService(self):
@@ -1908,11 +1909,11 @@ class WidgetSubcommandTests(unittest.TestCase):
                 'element': DummyLiveElement,
                 'port': 8080,
                 })
-        self.failUnless(isinstance(service, TCPServer))
+        self.assertTrue(isinstance(service, TCPServer))
         self.assertEqual(service.args[0], 8080)
-        self.failUnless(isinstance(service.args[1], NevowSite))
-        self.failUnless(isinstance(service.args[1].resource, WidgetPluginRoot))
-        self.failUnless(isinstance(service.args[1].resource.elementFactory(),
+        self.assertTrue(isinstance(service.args[1], NevowSite))
+        self.assertTrue(isinstance(service.args[1].resource, WidgetPluginRoot))
+        self.assertTrue(isinstance(service.args[1].resource.elementFactory(),
                                    DummyLiveElement))
 
 
@@ -1922,7 +1923,7 @@ class WidgetSubcommandTests(unittest.TestCase):
         particular LiveElement properly renders that element.
         """
         element = DummyLiveElement()
-        element.jsClass = u'Dummy.ClassName'
+        element.jsClass = 'Dummy.ClassName'
         element.docFactory = stan('the element')
         page = ElementRenderingLivePage(element)
         renderDeferred = renderLivePage(page)
@@ -1949,8 +1950,8 @@ class WidgetSubcommandTests(unittest.TestCase):
         page2, seg = w.locateChild(None, [''])
 
         # Make sure the pages aren't the same.
-        self.failUnless(isinstance(page1, ElementRenderingLivePage))
-        self.failUnless(isinstance(page2, ElementRenderingLivePage))
+        self.assertTrue(isinstance(page1, ElementRenderingLivePage))
+        self.assertTrue(isinstance(page2, ElementRenderingLivePage))
         self.assertNotIdentical(page1, page2)
 
         # Make sure the elements aren't the same.
@@ -1972,7 +1973,7 @@ class WidgetSubcommandTests(unittest.TestCase):
         w = WidgetPluginRoot(DummyLiveElement)
         page1, seg = w.locateChild(None, [''])
         page1.element.docFactory = stan('the element')
-        page1.element.jsClass = u'Dummy.ClassName'
+        page1.element.jsClass = 'Dummy.ClassName'
         def cbCheckPageByClientID(result):
             req = FakeRequest()
             ctx = WovenContext()

--- a/nevow/test/test_compression.py
+++ b/nevow/test/test_compression.py
@@ -1,7 +1,7 @@
 """
 Tests for on-the-fly content compression encoding.
 """
-from StringIO import StringIO
+from io import StringIO
 from gzip import GzipFile
 
 from zope.interface import implements

--- a/nevow/test/test_compression.py
+++ b/nevow/test/test_compression.py
@@ -4,7 +4,7 @@ Tests for on-the-fly content compression encoding.
 from io import StringIO
 from gzip import GzipFile
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import succeed
@@ -207,7 +207,7 @@ class RequestWrapperTests(TestCase):
         self.assertTrue(self.request.finished)
 
 
-
+@implementer(IResource)
 class TestResource(object):
     """
     L{IResource} implementation for testing.
@@ -218,7 +218,6 @@ class TestResource(object):
     @type segments: C{list}
     @ivar html: The data to return from C{renderHTTP}.
     """
-    implements(IResource)
 
     lastRequest = None
 
@@ -245,12 +244,11 @@ class TestResource(object):
         return self.html
 
 
-
+@implementer(IResource)
 class TestChildlessResource(object):
     """
     L{IResource} implementation with no children.
     """
-    implements(IResource)
 
     def locateChild(self, ctx, segments):
         """
@@ -259,12 +257,11 @@ class TestChildlessResource(object):
         return NotFound
 
 
-
+@implementer(IResource)
 class TestDeferredResource(object):
     """
     L{IResource} implementation with children.
     """
-    implements(IResource)
 
     def locateChild(self, ctx, segments):
         """
@@ -282,12 +279,11 @@ class TestResourceWrapper(CompressingResourceWrapper):
     Subclass for testing purposes, just to create a new type.
     """
 
-
+@implementer(IResource)
 class TestBrokenResource(object):
     """
     L{IResource} implementation that returns garbage from C{locateChild}.
     """
-    implements(IResource)
 
     def locateChild(self, ctx, segments):
         """

--- a/nevow/test/test_compression.py
+++ b/nevow/test/test_compression.py
@@ -154,10 +154,10 @@ class RequestWrapperTests(TestCase):
         Content-Length header should be discarded when compression is in use.
         """
         self.assertNotIn('content-length', self.request.headers)
-        self.wrapper.setHeader('content-length', 1234)
+        self.wrapper.setHeader(b'content-length', 1234)
         self.assertNotIn('content-length', self.request.headers)
 
-        self.request.setHeader('content-length', 1234)
+        self.request.setHeader(b'content-length', 1234)
         self.wrapper = CompressingRequestWrapper(self.request)
         self.assertNotIn('content-length', self.request.headers)
 

--- a/nevow/test/test_context.py
+++ b/nevow/test/test_context.py
@@ -24,31 +24,31 @@ class TestRememberLocate(TestCase):
         middle = context.WovenContext(top, tags.invisible())
         bottom = context.WovenContext(middle, tags.invisible())
         top.remember(0, IStuff)
-        self.assertEquals(bottom.locate(IStuff), 0)
+        self.assertEqual(bottom.locate(IStuff), 0)
         middle.remember(1, IStuff)
-        self.assertEquals(bottom.locate(IStuff), 1)
-        self.assertEquals(bottom.locate(IStuff, depth=2), 0)
+        self.assertEqual(bottom.locate(IStuff), 1)
+        self.assertEqual(bottom.locate(IStuff, depth=2), 0)
 
     def test_reverse(self):
         top = context.WovenContext().remember(0, IStuff)
         bottom = context.WovenContext(top, tags.invisible()).remember(1, IStuff)
-        self.assertEquals(bottom.locate(IStuff, depth=-1), 0)
+        self.assertEqual(bottom.locate(IStuff, depth=-1), 0)
 
     def test_page(self):
         page = context.PageContext(tag=1)
         page.remember(1, inevow.IData)
         ctx = context.WovenContext(page, tags.invisible())
-        self.assertEquals(ctx.locate(inevow.IData), 1)
-        self.assertEquals(ctx.locate(inevow.IData, depth=-1), 1)
+        self.assertEqual(ctx.locate(inevow.IData), 1)
+        self.assertEqual(ctx.locate(inevow.IData, depth=-1), 1)
 
     def test_factoryContext(self):
         ctx = TestContext()
-        self.assertEquals(IFoo(ctx), True)
+        self.assertEqual(IFoo(ctx), True)
 
     def test_factoryContextFromLocate(self):
         factory = TestContext()
         ctx = context.WovenContext(parent=factory)
-        self.assertEquals(IFoo(ctx), True)
+        self.assertEqual(IFoo(ctx), True)
 
     def test_factoryContextRemembers(self):
         basectx = TestContext()
@@ -72,7 +72,7 @@ class TestRememberLocate(TestCase):
         ctx = context.WovenContext()
         ctx.fillSlots('foo', 'bar')
         ctx = context.WovenContext(parent=ctx)
-        self.assertEquals(
+        self.assertEqual(
             ctx.locateSlotData('foo'),
             'bar')
 
@@ -94,7 +94,7 @@ class TestRememberLocate(TestCase):
 
         loops = 1e4
         before = time.clock()
-        for x in xrange(loops):
+        for x in range(loops):
             ignored = ctx.arg('foo')
             ignored = ctx.arg('bar')
         after = time.clock()
@@ -122,7 +122,7 @@ class IBar(zi.Interface):
 
 nextBar = itertools.count()
 def barFactory(ctx):
-    return nextBar.next()
+    return next(nextBar)
 
 registerAdapter(barFactory, TestContext, IBar)
 

--- a/nevow/test/test_disktemplate.py
+++ b/nevow/test/test_disktemplate.py
@@ -45,14 +45,14 @@ class TestHTMLRenderer(testutil.TestCase):
     def test_stringTemplate(self):
         r = rend.Page(docFactory=loaders.htmlstr(self.xhtml))
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, self.xhtml))
+            lambda result: self.assertEqual(result, self.xhtml))
 
     def test_diskTemplate(self):
         temp = self.mktemp()
         setContent(temp, self.xhtml)
         r = rend.Page(docFactory=loaders.htmlfile(temp))
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, self.xhtml))
+            lambda result: self.assertEqual(result, self.xhtml))
 
 
 class TestStandardRenderers(testutil.TestCase):
@@ -100,7 +100,7 @@ class TestStandardRenderers(testutil.TestCase):
         tr = TemplateRenderer(docFactory=loaders.htmlfile(temp))
 
         return deferredRender(tr).addCallback(
-            lambda result: self.assertEquals(
+            lambda result: self.assertEqual(
             result,
             '<html><head><title>THE TITLE</title></head><body><h3>THE HEADER</h3>SOME DUMMY TEXT</body></html>'
             ))
@@ -119,7 +119,7 @@ class TestStandardRenderers(testutil.TestCase):
 
         return deferredRender(tr).addCallback(
             lambda result:
-            self.assertEquals(
+            self.assertEqual(
             result, '<ol><li>one</li><li>two</li><li>three</li></ol>',
             "Whoops. We didn't get what we expected!"
             ))
@@ -138,7 +138,7 @@ class TestStandardRenderers(testutil.TestCase):
 
         return deferredRender(tr).addCallback(
             lambda result:
-            self.assertEquals(
+            self.assertEqual(
             result, '<ol><li><span>one</span></li><li><span>two</span></li><li><span>three</span></li></ol>',
             "Whoops. We didn't get what we expected!"
             ))
@@ -158,13 +158,13 @@ class TestStandardRenderers(testutil.TestCase):
             def data_aDict(self,context,data):
                 return {'1':'one','2':'two','3':'three','4':'four'}
             def render_slots(self,context,data):
-                for name,value in data.items():
+                for name,value in list(data.items()):
                     context.fillSlots(name, value)
                 return context.tag
 
         return deferredRender(Renderer(docFactory=loaders.htmlfile(temp))).addCallback(
             lambda result:
-            self.assertEquals(
+            self.assertEqual(
             result,
             "<table><tr><td>one</td><td>two</td></tr><tr><td>three</td><td>four</td></tr></table>",
             "Whoops. We didn't get what we expected!"))
@@ -183,11 +183,11 @@ class TestStandardRenderers(testutil.TestCase):
 
         return defer.DeferredList([
             deferredRender(Mine("one", docFactory=loaders.htmlfile(temp))).addCallback(
-            lambda result: self.assertEquals(result, '<span>ONE</span>')),
+            lambda result: self.assertEqual(result, '<span>ONE</span>')),
             deferredRender(Mine("two", docFactory=loaders.htmlfile(temp))).addCallback(
-            lambda result: self.assertEquals(result, '<span>TWO</span>')),
+            lambda result: self.assertEqual(result, '<span>TWO</span>')),
             deferredRender(Mine("three", docFactory=loaders.htmlfile(temp))).addCallback(
-            lambda result: self.assertEquals(result, '<span>THREE</span>'))
+            lambda result: self.assertEqual(result, '<span>THREE</span>'))
             ], fireOnOneErrback=True)
 
 
@@ -214,7 +214,7 @@ class TestSubclassAsRenderAndDataFactory(testutil.TestCase):
         def after(result):
             self.assertSubstring('hello', result)
             self.assertSubstring('world', result)
-            self.assertEquals(result,
+            self.assertEqual(result,
                               "<html><div>hello</div>world</html>")
         return D.addCallback(after)
 

--- a/nevow/test/test_element.py
+++ b/nevow/test/test_element.py
@@ -182,7 +182,7 @@ class FlattenIntegrationTests(TestCase):
         """
         f = Element(docFactory=stan(p["Hello, world."]))
         return self._render(f).addCallback(
-            self.assertEquals, "<p>Hello, world.</p>")
+            self.assertEqual, "<p>Hello, world.</p>")
 
 
     def test_docFactoryClassAttribute(self):
@@ -194,7 +194,7 @@ class FlattenIntegrationTests(TestCase):
         class SubElement(Element):
             docFactory = stan(p["Hello, world."])
         return self._render(SubElement()).addCallback(
-            self.assertEquals, "<p>Hello, world.</p>")
+            self.assertEqual, "<p>Hello, world.</p>")
 
 
     def test_simpleXHTMLRendering(self):
@@ -204,7 +204,7 @@ class FlattenIntegrationTests(TestCase):
         """
         f = Element(docFactory=xmlstr("<p>Hello, world.</p>"))
         return self._render(f).addCallback(
-            self.assertEquals, "<p>Hello, world.</p>")
+            self.assertEqual, "<p>Hello, world.</p>")
 
 
     def test_stanDirectiveRendering(self):
@@ -242,7 +242,7 @@ class FlattenIntegrationTests(TestCase):
             docFactory=stan(p(render=directive('renderMethod'))[
                     "Goodbye, world."]))
         return self._render(f).addCallback(
-            self.assertEquals, "Hello, world.")
+            self.assertEqual, "Hello, world.")
 
 
     def test_elementContainingStaticElement(self):
@@ -257,7 +257,7 @@ class FlattenIntegrationTests(TestCase):
         f = RenderfulElement(
             docFactory=stan(p(render=directive('renderMethod'))))
         return self._render(f).addCallback(
-            self.assertEquals, "<p>Hello, world.</p>")
+            self.assertEqual, "<p>Hello, world.</p>")
 
 
     def test_elementContainingDynamicElement(self):
@@ -277,7 +277,7 @@ class FlattenIntegrationTests(TestCase):
         f = OuterElement(
             docFactory=stan(p(render=directive('outerMethod'))))
         return self._render(f).addCallback(
-            self.assertEquals, "<p>Hello, world.</p>")
+            self.assertEqual, "<p>Hello, world.</p>")
 
 
     def test_synchronousFlatten(self):

--- a/nevow/test/test_errorhandler.py
+++ b/nevow/test/test_errorhandler.py
@@ -1,5 +1,5 @@
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.python import log
 from twisted.internet import defer
 from nevow import appserver, context, inevow, loaders, rend, tags as T, testutil
@@ -9,9 +9,8 @@ class Root(rend.Page):
     docFactory = loaders.stan(T.html[T.p['Root']])
 
 
-
+@implementer(inevow.ICanHandleNotFound)
 class NotFoundHandler(object):
-    implements(inevow.ICanHandleNotFound)
     html = 'NotFoundHandler'
     def renderHTTP_notFound(self, ctx):
         return self.html
@@ -19,8 +18,8 @@ class NotFoundHandler(object):
 class BrokenException(Exception):
     pass
 
+@implementer(inevow.ICanHandleNotFound)
 class BadNotFoundHandler(object):
-    implements(inevow.ICanHandleNotFound)
     html = 'NotFoundHandler'
     exceptionType = BrokenException
     exceptionMessage ='Error from BadNotFoundHandler'

--- a/nevow/test/test_errorhandler.py
+++ b/nevow/test/test_errorhandler.py
@@ -61,25 +61,28 @@ class Test404(testutil.TestCase):
         """
         root = Root()
         def later(resource):
-            self.failUnless(isinstance(resource, rend.FourOhFour))
-            def morelater((code, html)):
-                self.assertEquals(rend.FourOhFour.notFound, html)
-                self.assertEquals(code, 404)
+            self.assertTrue(isinstance(resource, rend.FourOhFour))
+            def morelater(xxx_todo_changeme):
+                (code, html) = xxx_todo_changeme
+                self.assertEqual(rend.FourOhFour.notFound, html)
+                self.assertEqual(code, 404)
             return renderResource('/foo').addCallback(morelater)
         return getResource(root, '/foo').addCallback(later)
 
     def test_remembered404Handler(self):
-        def later((code, html)):
-            self.assertEquals(html, NotFoundHandler.html)
-            self.assertEquals(code, 404)
+        def later(xxx_todo_changeme1):
+            (code, html) = xxx_todo_changeme1
+            self.assertEqual(html, NotFoundHandler.html)
+            self.assertEqual(code, 404)
 
         return renderResource('/foo', notFoundHandler=NotFoundHandler()).addCallback(later)
 
     def test_keyErroringNotFoundHandler(self):
-        def later((code, html)):
-            self.assertEquals(rend.FourOhFour.notFound, html)
-            self.assertEquals(code, 404)
+        def later(xxx_todo_changeme2):
+            (code, html) = xxx_todo_changeme2
+            self.assertEqual(rend.FourOhFour.notFound, html)
+            self.assertEqual(code, 404)
             fe = self.flushLoggedErrors(BrokenException)
-            self.assertEquals(len(fe), 1)
+            self.assertEqual(len(fe), 1)
         return renderResource('/foo', notFoundHandler=BadNotFoundHandler()).addCallback(later)
 

--- a/nevow/test/test_flatsax.py
+++ b/nevow/test/test_flatsax.py
@@ -104,38 +104,38 @@ class Basic(TestCase):
 
     def test_parseString(self):
         xml = '''<html></html>'''
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_attrs(self):
         xml = '''<p class="foo"></p>'''
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_xmlns(self):
         xml = '''<html xmlns="http://www.w3.org/1999/xhtml"></html>'''
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_processingInstruction(self):
         xml = '''<html></html>'''
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_doctype(self):
         xml = (
             '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" '
             '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n'
             '<html></html>')
-        self.failUnlessEqual(norm(xml), norm(flatten(parseString(xml))))
+        self.assertEqual(norm(xml), norm(flatten(parseString(xml))))
 
     def test_entities(self):
         xml = """<p>&amp;</p>"""
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_cdata(self):
         xml = '<script type="text/javascript"><![CDATA[&lt;abc]]></script>'
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_comment(self):
         xml = '<!-- comment &amp;&pound; --><html></html>'
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_commentWhereSpacingMatters(self):
         """
@@ -150,19 +150,19 @@ div.logo {
 </style>
 <![endif]-->
 </head>"""
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_unicodeComment(self):
         xml = '<!-- \xc2\xa3 --><html></html>'
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_xmlAttr(self):
         xml = '<html xml:lang="en"></html>'
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_badNamespace(self):
         xml = '<html foo:bar="wee"><abc:p>xyz</abc:p></html>'
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
     test_badNamespace.skip = (
         'the standard 2.3 sax parser likes all namespaces to be defined '
         'so this test fails. it does pass with python-xml')
@@ -173,7 +173,7 @@ div.logo {
             '<p>in default namespace</p>'
             '<foo:div xmlns:foo="http://www.w3.org/1999/xhtml">'
             '<foo:p>in foo namespace</foo:p></foo:div></html>')
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_otherns(self):
         xml = (
@@ -181,7 +181,7 @@ div.logo {
             'xmlns:xf="http://www.w3.org/2002/xforms"><p>'
             'in default namespace</p><xf:input><xf:label>'
             'in another namespace</xf:label></xf:input></html>')
-        self.failUnlessEqual(xml, flatten(parseString(xml)))
+        self.assertEqual(xml, flatten(parseString(xml)))
 
     def test_invisiblens(self):
         """
@@ -190,4 +190,4 @@ div.logo {
         xml = (
             '<p xmlns:n="http://nevow.com/ns/nevow/0.1">'
             '<n:invisible>123</n:invisible></p>')
-        self.failUnlessEqual('<p>123</p>', flatten(parseString(xml)))
+        self.assertEqual('<p>123</p>', flatten(parseString(xml)))

--- a/nevow/test/test_flatstan.py
+++ b/nevow/test/test_flatstan.py
@@ -3,7 +3,7 @@
 
 from twisted.internet import defer
 
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from nevow import stan
 from nevow import context
@@ -356,8 +356,9 @@ class TestComplexSerialization(Base):
     def test_nested_remember(self):
         class IFoo(Interface):
             pass
+        @implementer(IFoo)
         class Foo(str):
-            implements(IFoo)
+            pass
 
         def checkContext(ctx, data):
             self.assertEqual(ctx.locate(IFoo), Foo("inner"))

--- a/nevow/test/test_flatstan.py
+++ b/nevow/test/test_flatstan.py
@@ -49,21 +49,21 @@ class Base(TestCase):
 
 class TestSimpleSerialization(Base):
     def test_serializeProto(self):
-        self.assertEquals(self.render(proto), '<hello />')
+        self.assertEqual(self.render(proto), '<hello />')
 
     def test_serializeTag(self):
         tag = proto(someAttribute="someValue")
-        self.assertEquals(self.render(tag), '<hello someAttribute="someValue"></hello>')
+        self.assertEqual(self.render(tag), '<hello someAttribute="someValue"></hello>')
 
     def test_serializeChildren(self):
         tag = proto(someAttribute="someValue")[
             proto
         ]
-        self.assertEquals(self.render(tag), '<hello someAttribute="someValue"><hello /></hello>')
+        self.assertEqual(self.render(tag), '<hello someAttribute="someValue"><hello /></hello>')
 
     def test_serializeWithData(self):
         tag = proto(data=5)
-        self.assertEquals(self.render(tag), '<hello></hello>')
+        self.assertEqual(self.render(tag), '<hello></hello>')
 
     def test_adaptRenderer(self):
         ## This is an implementation of the "adapt" renderer
@@ -72,19 +72,19 @@ class TestSimpleSerialization(Base):
                 data
             ]
         tag = proto(data=5, render=_)
-        self.assertEquals(self.render(tag), '<hello>5</hello>')
+        self.assertEqual(self.render(tag), '<hello>5</hello>')
 
     def test_serializeDataWithRenderer(self):
         tag = proto(data=5, render=str)
-        self.assertEquals(self.render(tag), '5')
+        self.assertEqual(self.render(tag), '5')
 
     def test_noContextRenderer(self):
         def _(data):
             return data
         tag = proto(data=5, render=_)
-        self.assertEquals(self.render(tag), '5')
+        self.assertEqual(self.render(tag), '5')
         tag = proto(data=5, render=lambda data: data)
-        self.assertEquals(self.render(tag), '5')
+        self.assertEqual(self.render(tag), '5')
 
     def test_aBunchOfChildren(self):
         tag = proto[
@@ -92,28 +92,28 @@ class TestSimpleSerialization(Base):
             5,
             "A friend in need is a friend indeed"
         ]
-        self.assertEquals(self.render(tag), '<hello>A Child5A friend in need is a friend indeed</hello>')
+        self.assertEqual(self.render(tag), '<hello>A Child5A friend in need is a friend indeed</hello>')
 
     def test_basicPythonTypes(self):
         tag = proto(data=5)[
             "A string; ",
-            u"A unicode string; ",
+            "A unicode string; ",
             5, " (An integer) ",
             1.0, " (A float) ",
-            1L, " (A long) ",
+            1, " (A long) ",
             True, " (A bool) ",
             ["A ", "List; "],
             stan.xml("<xml /> Some xml; "),
             lambda data: "A function"
         ]
         if self.hasBools:
-            self.assertEquals(self.render(tag), "<hello>A string; A unicode string; 5 (An integer) 1.0 (A float) 1 (A long) True (A bool) A List; <xml /> Some xml; A function</hello>")
+            self.assertEqual(self.render(tag), "<hello>A string; A unicode string; 5 (An integer) 1.0 (A float) 1 (A long) True (A bool) A List; <xml /> Some xml; A function</hello>")
         else:
-            self.assertEquals(self.render(tag), "<hello>A string; A unicode string; 5 (An integer) 1.0 (A float) 1 (A long) 1 (A bool) A List; <xml /> Some xml; A function</hello>")
+            self.assertEqual(self.render(tag), "<hello>A string; A unicode string; 5 (An integer) 1.0 (A float) 1 (A long) 1 (A bool) A List; <xml /> Some xml; A function</hello>")
 
     def test_escaping(self):
         tag = proto(foo="<>&\"'")["<>&\"'"]
-        self.assertEquals(self.render(tag), '<hello foo="&lt;&gt;&amp;&quot;\'">&lt;&gt;&amp;"\'</hello>')
+        self.assertEqual(self.render(tag), '<hello foo="&lt;&gt;&amp;&quot;\'">&lt;&gt;&amp;"\'</hello>')
 
 
 class TestComplexSerialization(Base):
@@ -127,11 +127,11 @@ class TestComplexSerialization(Base):
             ]
         ]
         prelude, context, postlude = self.render(tag, precompile=True)
-        self.assertEquals(prelude, "<html><body><div><p>Here's a string</p>")
-        self.assertEquals(context.tag.tagName, "p")
-        self.assertEquals(context.tag.data, 5)
-        self.assertEquals(context.tag.render, str)
-        self.assertEquals(postlude, '</div></body></html>')
+        self.assertEqual(prelude, "<html><body><div><p>Here's a string</p>")
+        self.assertEqual(context.tag.tagName, "p")
+        self.assertEqual(context.tag.data, 5)
+        self.assertEqual(context.tag.render, str)
+        self.assertEqual(postlude, '</div></body></html>')
 
     def test_precompileSlotData(self):
         """Test that tags with slotData are not precompiled out of the
@@ -140,7 +140,7 @@ class TestComplexSerialization(Base):
         tag = tags.p[tags.slot('foo')]
         tag.fillSlots('foo', 'bar')
         precompiled = self.render(tag, precompile=True)
-        self.assertEquals(self.render(precompiled), '<p>bar</p>')
+        self.assertEqual(self.render(precompiled), '<p>bar</p>')
 
 
     def test_precompiledSlotLocation(self):
@@ -186,7 +186,7 @@ class TestComplexSerialization(Base):
         result1 = self.render(doc, precompile=True)
         result2 = self.render(doc, precompile=True)
         rendered = self.render(result2)
-        self.assertEquals(rendered, "<html><body><p>Hello</p><p>5</p></body></html>")
+        self.assertEqual(rendered, "<html><body><p>Hello</p><p>5</p></body></html>")
 
     def test_precompilePrecompiled(self):
         def render_same(context, data):
@@ -203,7 +203,7 @@ class TestComplexSerialization(Base):
         result1 = self.render(doc, precompile=True)
         result2 = self.render(result1, precompile=True)
         rendered = self.render(result2)
-        self.assertEquals(rendered, "<html><body><p>Hello</p><p>5</p></body></html>")
+        self.assertEqual(rendered, "<html><body><p>Hello</p><p>5</p></body></html>")
 
     def test_precompileDoesntChangeOriginal(self):
         doc = tags.html(data="foo")[tags.p['foo'], tags.p['foo']]
@@ -211,37 +211,37 @@ class TestComplexSerialization(Base):
         result = self.render(doc, precompile=True)
         rendered = self.render(result)
 
-        self.assertEquals(len(doc.children), 2)
-        self.assertEquals(rendered, "<html><p>foo</p><p>foo</p></html>")
+        self.assertEqual(len(doc.children), 2)
+        self.assertEqual(rendered, "<html><p>foo</p><p>foo</p></html>")
 
     def test_precompileNestedDynamics(self):
         tag = self.makeComplex()
         prelude, dynamic, postlude = self.render(tag, precompile=True)
-        self.assertEquals(prelude, '<html><body>')
+        self.assertEqual(prelude, '<html><body>')
 
-        self.assertEquals(dynamic.tag.tagName, 'table')
-        self.failUnless(dynamic.tag.children)
-        self.assertEquals(dynamic.tag.data, 5)
+        self.assertEqual(dynamic.tag.tagName, 'table')
+        self.assertTrue(dynamic.tag.children)
+        self.assertEqual(dynamic.tag.data, 5)
 
         childPrelude, childDynamic, childPostlude = dynamic.tag.children
 
-        self.assertEquals(childPrelude, '<tr><td>')
-        self.assertEquals(childDynamic.tag.tagName, 'span')
-        self.assertEquals(childDynamic.tag.render, str)
-        self.assertEquals(childPostlude, '</td></tr>')
+        self.assertEqual(childPrelude, '<tr><td>')
+        self.assertEqual(childDynamic.tag.tagName, 'span')
+        self.assertEqual(childDynamic.tag.render, str)
+        self.assertEqual(childPostlude, '</td></tr>')
 
-        self.assertEquals(postlude, '</body></html>')
+        self.assertEqual(postlude, '</body></html>')
 
     def test_precompileThenRender(self):
         tag = self.makeComplex()
         prerendered = self.render(tag, precompile=True)
-        self.assertEquals(self.render(prerendered), '<html><body><table><tr><td>5</td></tr></table></body></html>')
+        self.assertEqual(self.render(prerendered), '<html><body><table><tr><td>5</td></tr></table></body></html>')
 
     def test_precompileThenMultipleRenders(self):
         tag = self.makeComplex()
         prerendered = self.render(tag, precompile=True)
-        self.assertEquals(self.render(prerendered), '<html><body><table><tr><td>5</td></tr></table></body></html>')
-        self.assertEquals(self.render(prerendered), '<html><body><table><tr><td>5</td></tr></table></body></html>')
+        self.assertEqual(self.render(prerendered), '<html><body><table><tr><td>5</td></tr></table></body></html>')
+        self.assertEqual(self.render(prerendered), '<html><body><table><tr><td>5</td></tr></table></body></html>')
 
     def test_patterns(self):
         tag = tags.html[
@@ -253,12 +253,12 @@ class TestComplexSerialization(Base):
                 ]
             ]
         ]
-        self.assertEquals(self.render(tag), "<html><body><ol><li>one</li><li>two</li><li>three</li></ol></body></html>")
+        self.assertEqual(self.render(tag), "<html><body><ol><li>one</li><li>two</li><li>three</li></ol></body></html>")
 
     def test_precompilePatternWithNoChildren(self):
         tag = tags.img(pattern='item')
         pc = flat.precompile(tag)
-        self.assertEquals(pc[0].tag.children, [])
+        self.assertEqual(pc[0].tag.children, [])
 
     def test_slots(self):
         tag = tags.html[
@@ -272,7 +272,7 @@ class TestComplexSerialization(Base):
                 ]
             ]
         ]
-        self.assertEquals(self.render(tag), "<html><body><table><tr><td>Header one.</td><td>Header two.</td></tr><tr><td>One: 1</td><td>Two: 2</td></tr></table></body></html>")
+        self.assertEqual(self.render(tag), "<html><body><table><tr><td>Header one.</td><td>Header two.</td></tr><tr><td>One: 1</td><td>Two: 2</td></tr></table></body></html>")
 
 
     def test_slotAttributeEscapingWhenPrecompiled(self):
@@ -291,7 +291,7 @@ class TestComplexSerialization(Base):
         # this test passes if the precompile test is skipped.
         precompiled = self.render(tag, precompile=True)
 
-        self.assertEquals(self.render(precompiled), '<input value="&quot;meow&quot;" />')
+        self.assertEqual(self.render(precompiled), '<input value="&quot;meow&quot;" />')
 
 
     def test_nestedpatterns(self):
@@ -309,7 +309,7 @@ class TestComplexSerialization(Base):
                 ]
             ]
         ]
-        self.assertEquals(self.render(tag), "<html><body><table><tr><td>col1</td><td>col2</td><td>col3</td></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>4</td><td>5</td><td>6</td></tr></table></body></html>")
+        self.assertEqual(self.render(tag), "<html><body><table><tr><td>col1</td><td>col2</td><td>col3</td></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>4</td><td>5</td><td>6</td></tr></table></body></html>")
 
     def test_cloning(self):
         def data_foo(context, data):  return [{'foo':'one'}, {'foo':'two'}]
@@ -334,24 +334,24 @@ class TestComplexSerialization(Base):
             ]
         ]
         document=self.render(document, precompile=True)
-        self.assertEquals(self.render(document), '<html><body><ul><li><a href="test/one">link</a></li><li><a href="test/two">link</a></li></ul><ul><li>fooone</li><li>footwo</li></ul></body></html>')
+        self.assertEqual(self.render(document), '<html><body><ul><li><a href="test/one">link</a></li><li><a href="test/two">link</a></li></ul><ul><li>fooone</li><li>footwo</li></ul></body></html>')
 
     def test_singletons(self):
         for x in ('img', 'br', 'hr', 'base', 'meta', 'link', 'param', 'area',
             'input', 'col', 'basefont', 'isindex', 'frame'):
-            self.assertEquals(self.render(tags.Proto(x)()), '<%s />' % x)
+            self.assertEqual(self.render(tags.Proto(x)()), '<%s />' % x)
 
     def test_nosingleton(self):
         for x in ('div', 'span', 'script', 'iframe'):
-            self.assertEquals(self.render(tags.Proto(x)()), '<%(tag)s></%(tag)s>' % {'tag': x})
+            self.assertEqual(self.render(tags.Proto(x)()), '<%(tag)s></%(tag)s>' % {'tag': x})
 
     def test_nested_data(self):
         def checkContext(ctx, data):
-            self.assertEquals(data, "inner")
-            self.assertEquals(ctx.locate(inevow.IData, depth=2), "outer")
+            self.assertEqual(data, "inner")
+            self.assertEqual(ctx.locate(inevow.IData, depth=2), "outer")
             return 'Hi'
         tag = tags.html(data="outer")[tags.span(render=lambda ctx,data: ctx.tag, data="inner")[checkContext]]
-        self.assertEquals(self.render(tag), "<html><span>Hi</span></html>")
+        self.assertEqual(self.render(tag), "<html><span>Hi</span></html>")
 
     def test_nested_remember(self):
         class IFoo(Interface):
@@ -360,11 +360,11 @@ class TestComplexSerialization(Base):
             implements(IFoo)
 
         def checkContext(ctx, data):
-            self.assertEquals(ctx.locate(IFoo), Foo("inner"))
-            self.assertEquals(ctx.locate(IFoo, depth=2), Foo("outer"))
+            self.assertEqual(ctx.locate(IFoo), Foo("inner"))
+            self.assertEqual(ctx.locate(IFoo, depth=2), Foo("outer"))
             return 'Hi'
         tag = tags.html(remember=Foo("outer"))[tags.span(render=lambda ctx,data: ctx.tag, remember=Foo("inner"))[checkContext]]
-        self.assertEquals(self.render(tag), "<html><span>Hi</span></html>")
+        self.assertEqual(self.render(tag), "<html><span>Hi</span></html>")
 
     def test_deferredRememberInRenderer(self):
         class IFoo(Interface):
@@ -376,7 +376,7 @@ class TestComplexSerialization(Base):
             return IFoo(ctx)
         tag = tags.invisible(render=rememberIt)[tags.invisible(render=locateIt)]
         self.render(tag, wantDeferred=True).addCallback(
-            lambda result: self.assertEquals(result, "bar"))
+            lambda result: self.assertEqual(result, "bar"))
 
     def test_deferredFromNestedFunc(self):
         def outer(ctx, data):
@@ -384,14 +384,14 @@ class TestComplexSerialization(Base):
                 return defer.succeed(tags.p['Hello'])
             return inner
         self.render(tags.invisible(render=outer), wantDeferred=True).addCallback(
-            lambda result: self.assertEquals(result, '<p>Hello</p>'))
+            lambda result: self.assertEqual(result, '<p>Hello</p>'))
 
     def test_dataContextCreation(self):
         data = {'foo':'oof', 'bar':'rab'}
         doc = tags.p(data=data)[tags.slot('foo'), tags.slot('bar')]
         doc.fillSlots('foo', tags.invisible(data=tags.directive('foo'), render=str))
         doc.fillSlots('bar', lambda ctx,data: data['bar'])
-        self.assertEquals(flat.flatten(doc), '<p>oofrab</p>')
+        self.assertEqual(flat.flatten(doc), '<p>oofrab</p>')
 
     def test_leaky(self):
         def foo(ctx, data):
@@ -403,7 +403,7 @@ class TestComplexSerialization(Base):
                 tags.slot("bar"),
                 tags.invisible(render=str)])
 
-        self.assertEquals(result, '<div>one</div>')
+        self.assertEqual(result, '<div>one</div>')
 
 
 class TestMultipleRenderWithDirective(Base):
@@ -433,37 +433,37 @@ class TestMultipleRenderWithDirective(Base):
 class TestEntity(Base):
     def test_it(self):
         val = self.render(entities.nbsp)
-        self.assertEquals(val, '&#160;')
+        self.assertEqual(val, '&#160;')
 
     def test_nested(self):
         val = self.render(tags.html(src=entities.quot)[entities.amp])
-        self.assertEquals(val, '<html src="&quot;">&amp;</html>')
+        self.assertEqual(val, '<html src="&quot;">&amp;</html>')
 
     def test_xml(self):
         val = self.render([entities.lt, entities.amp, entities.gt])
-        self.assertEquals(val, '&lt;&amp;&gt;')
+        self.assertEqual(val, '&lt;&amp;&gt;')
 
 
 class TestNoneAttribute(Base):
 
     def test_simple(self):
         val = self.render(tags.html(foo=None)["Bar"])
-        self.assertEquals(val, "<html>Bar</html>")
+        self.assertEqual(val, "<html>Bar</html>")
 
     def test_slot(self):
         val = self.render(tags.html().fillSlots('bar', None)(foo=tags.slot('bar'))["Bar"])
-        self.assertEquals(val, "<html>Bar</html>")
+        self.assertEqual(val, "<html>Bar</html>")
     test_slot.skip = "Attribute name flattening must happen later for this to work"
 
     def test_deepSlot(self):
         val = self.render(tags.html().fillSlots('bar', lambda c,d: None)(foo=tags.slot('bar'))["Bar"])
-        self.assertEquals(val, "<html>Bar</html>")
+        self.assertEqual(val, "<html>Bar</html>")
     test_deepSlot.skip = "Attribute name flattening must happen later for this to work"
 
     def test_deferredSlot(self):
         self.render(tags.html().fillSlots('bar', defer.succeed(None))(foo=tags.slot('bar'))["Bar"],
                     wantDeferred=True).addCallback(
-            lambda val: self.assertEquals(val, "<html>Bar</html>"))
+            lambda val: self.assertEqual(val, "<html>Bar</html>"))
     test_deferredSlot.skip = "Attribute name flattening must happen later for this to work"
 
 
@@ -478,7 +478,7 @@ class TestKey(Base):
                 tags.div(key="two", render=appendKey)[
                     tags.div(render=appendKey)[
                         tags.div(key="four", render=appendKey)]]])
-        self.assertEquals(val, ["one", "one.two", "one.two", "one.two.four"])
+        self.assertEqual(val, ["one", "one.two", "one.two", "one.two.four"])
 
 
 
@@ -507,7 +507,7 @@ class TestDeferFlatten(Base):
         # The actual test
         notquiteglobals = {}
         def finished(spam):
-            print 'FINISHED'
+            print('FINISHED')
         def error(failure):
             notquiteglobals['exception'] = failure.value
         def checker(result):

--- a/nevow/test/test_flatten.py
+++ b/nevow/test/test_flatten.py
@@ -9,25 +9,25 @@ from nevow.testutil import TestCase
 
 class TestSerialization(TestCase):
     def test_someTypes(self):
-        self.assertEquals(ten.flatten(1), '1')
-        self.assertEquals(ten.flatten([1,2,3]), '123')
+        self.assertEqual(ten.flatten(1), '1')
+        self.assertEqual(ten.flatten([1,2,3]), '123')
 
     def test_nestedTags(self):
-        self.assertEquals(
+        self.assertEqual(
             ten.flatten(
                 tags.html(hi='there')[
                     tags.body[ 42 ]]),
             '<html hi="there"><body>42</body></html>')
 
     def test_dynamic(self):
-        self.assertEquals(
+        self.assertEqual(
             ten.flatten(
                 tags.html[
                     tags.body(render=lambda c, d: 'body!')]),
             '<html>body!</html>')
 
     def test_reallyDynamic(self):
-        self.assertEquals(
+        self.assertEqual(
             ten.flatten(
                 tags.html[
                     lambda c, d: tags.body[
@@ -35,24 +35,24 @@ class TestSerialization(TestCase):
             '<html><body>stuff</body></html>')
 
     def test_serializeString(self):
-        self.assertEquals(ten.flatten('one'), 'one')
-        self.assertEquals(type(ten.flatten('<>')), tags.raw)
-        self.assertEquals(ten.flatten('<abc&&>123'), '&lt;abc&amp;&amp;&gt;123')
-        self.assertEquals(ten.flatten(tags.xml('<>&')), '<>&')
-        self.assertEquals(ten.flatten(tags.xml(u'\xc2\xa3')), '\xc3\x82\xc2\xa3')
+        self.assertEqual(ten.flatten('one'), 'one')
+        self.assertEqual(type(ten.flatten('<>')), tags.raw)
+        self.assertEqual(ten.flatten('<abc&&>123'), '&lt;abc&amp;&amp;&gt;123')
+        self.assertEqual(ten.flatten(tags.xml('<>&')), '<>&')
+        self.assertEqual(ten.flatten(tags.xml('\xc2\xa3')), '\xc3\x82\xc2\xa3')
         
     def test_flattenTwice(self):
         """Test that flattening a string twice does not encode it twice.
         """
-        self.assertEquals(ten.flatten(ten.flatten('&')), '&amp;')
+        self.assertEqual(ten.flatten(ten.flatten('&')), '&amp;')
 
 
 class TestPrecompile(TestCase):
     def test_simple(self):
-        self.assertEquals(ten.precompile(1), ['1'])
+        self.assertEqual(ten.precompile(1), ['1'])
 
     def test_complex(self):
-        self.assertEquals(ten.precompile(
+        self.assertEqual(ten.precompile(
             tags.html[
                 tags.head[
                     tags.title["Hi"]],
@@ -66,10 +66,10 @@ class TestPrecompile(TestCase):
             tags.html[
                 render])
         prelude, dynamic, postlude = result
-        self.assertEquals(prelude, '<html>')
-        self.assertEquals(dynamic.tag.render, render)
-        self.assertEquals(postlude, '</html>')
-        self.assertEquals(ten.flatten(result), '<html>one</html>')
+        self.assertEqual(prelude, '<html>')
+        self.assertEqual(dynamic.tag.render, render)
+        self.assertEqual(postlude, '</html>')
+        self.assertEqual(ten.flatten(result), '<html>one</html>')
 
     def test_tagWithRender(self):
         render = lambda c, d: 'body'
@@ -77,10 +77,10 @@ class TestPrecompile(TestCase):
             tags.html[
                 tags.body(render=render)])
         prelude, dynamic, postlude = result
-        self.assertEquals(prelude, '<html>')
-        self.assertEquals(dynamic.tag.render, render)
-        self.assertEquals(postlude, '</html>')
-        self.assertEquals(ten.flatten(result), '<html>body</html>')
+        self.assertEqual(prelude, '<html>')
+        self.assertEqual(dynamic.tag.render, render)
+        self.assertEqual(postlude, '</html>')
+        self.assertEqual(ten.flatten(result), '<html>body</html>')
 
 
 import unicodedata
@@ -90,10 +90,10 @@ u = unicodedata.lookup('QUARTER NOTE')
 class TestUnicode(TestCase):
     
     def test_it(self):
-        self.assertEquals(ten.flatten(u), u.encode('utf8'))
+        self.assertEqual(ten.flatten(u), u.encode('utf8'))
 
     def test_unescaped(self):
-        self.assertEquals(ten.flatten(tags.xml(u'<<<%s>>>' % u)), (u'<<<%s>>>' % u).encode('utf8'))
+        self.assertEqual(ten.flatten(tags.xml('<<<%s>>>' % u)), ('<<<%s>>>' % u).encode('utf8'))
     
 class Registration(TestCase):
     def testBadRegister(self):

--- a/nevow/test/test_guard.py
+++ b/nevow/test/test_guard.py
@@ -7,7 +7,7 @@ Tests for L{nevow.guard}.
 
 import gc
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse, AllowAnonymousAccess, ANONYMOUS
 from twisted.cred.portal import Portal, IRealm
@@ -168,9 +168,8 @@ class SillyAnonymous(SillyPage):
     def renderHTTP(self, ctx):
         return 'No'
 
-
+@implementer(IRealm)
 class SillyRealm:
-    implements(IRealm)
 
     def __init__(self, anonymousAvatarFactory=SillyAnonymous,
                  authenticatedAvatarFactory=SillyAvatar):
@@ -242,8 +241,8 @@ class GetLoggedInAnonymous(rend.Page):
     def renderHTTP(self, ctx):
         raise RuntimeError("We weren't supposed to get here.")
 
+@implementer(IRealm)
 class GetLoggedInRealm:
-    implements(IRealm)
 
     def requestAvatar(self, avatarId, mind, *interfaces):
         if avatarId == ANONYMOUS:
@@ -530,9 +529,8 @@ class GuardTestFuncs:
         class TrailingSlashAnonymous(TrailingSlashPage):
             def renderHTTP(self, ctx):
                 return 'Anonymous %s' % self.original
-
+        @implementer(IRealm)
         class TrailingSlashRealm:
-            implements(IRealm)
 
             def __init__(self, path):
                 self.path = path
@@ -575,9 +573,8 @@ class GuardTestFuncs:
         class TrailingSlashAnonymous(TrailingSlashPage):
             def renderHTTP(self, ctx):
                 return 'Anonymous %s' % self.original
-
+        @implementer(IRealm)
         class TrailingSlashRealm:
-            implements(IRealm)
 
             def __init__(self, path):
                 self.path = path

--- a/nevow/test/test_guard.py
+++ b/nevow/test/test_guard.py
@@ -70,7 +70,7 @@ class FakeHTTPRequest(appserver.NevowRequest):
         appserver.NevowRequest.__init__(self, *args, **kw)
         self._pchn = self.channel
         self._cookieCache = {}
-        from cStringIO import StringIO
+        from io import StringIO
         self.content = StringIO()
         self.received_headers['host'] = 'fake.com'
         self.written = StringIO()
@@ -91,7 +91,7 @@ class FakeHTTPRequest(appserver.NevowRequest):
         R = self
         MAX_REDIRECTS = 5
         I = 1
-        while R.headers.has_key('location'):
+        while 'location' in R.headers:
             assert I < MAX_REDIRECTS, "Too many redirects (to %s)" % R.headers['location']
             R = R.followRedirect()
             I += 1
@@ -103,7 +103,7 @@ class FakeHTTPRequest(appserver.NevowRequest):
 
     def addCookie(self, k, v, *args,**kw):
         appserver.NevowRequest.addCookie(self,k,v,*args,**kw)
-        assert not self._cookieCache.has_key(k), "Should not be setting duplicate cookies!"
+        assert k not in self._cookieCache, "Should not be setting duplicate cookies!"
         self._cookieCache[k] = (v, args, kw)
         self.channel.received_cookies[k] = v
 
@@ -197,7 +197,7 @@ class GuardTestSuper(TestCase):
     sessions = {}
 
     def tearDown(self):
-        for sz in self.sessions.values():
+        for sz in list(self.sessions.values()):
             sz.expire()
 
     def createPortal(self, realmFactory=None):
@@ -223,7 +223,7 @@ def getGuard(channel):
     resource = channel.site.resource
     while isinstance(resource, ParentPage):
         assert len(resource.children) == 1
-        resource = resource.children.values()[0]
+        resource = list(resource.children.values())[0]
     return resource
 
 
@@ -240,7 +240,7 @@ class GetLoggedInAvatar(rend.Page):
 class GetLoggedInAnonymous(rend.Page):
     def child_(self, ctx): return self
     def renderHTTP(self, ctx):
-        raise RuntimeError, "We weren't supposed to get here."
+        raise RuntimeError("We weren't supposed to get here.")
 
 class GetLoggedInRealm:
     implements(IRealm)
@@ -293,8 +293,8 @@ class GuardTestFuncs:
         # each time, and there should only ever be one session.
         for x in range(3):
             req = chan.makeFakeRequest('%s/' % self.getGuardPath(), "test", "test")
-            self.assertEquals(req.written.getvalue(), "Yes")
-            self.assertEquals(len(self.sessions), 1)
+            self.assertEqual(req.written.getvalue(), "Yes")
+            self.assertEqual(len(self.sessions), 1)
 
 
     def test_sessionInit(self):
@@ -312,27 +312,27 @@ class GuardTestFuncs:
         # The first thing that happens when we attempt to browse with no session
         # is a cookie being set and a redirect being issued to the session url
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath())
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
         # The redirect is set immediately and should have a path segment at the beginning matching our cookie
-        self.failUnless(req.headers.has_key('location'))
-        cookie = req._cookieCache.values()[0][0]
+        self.assertTrue('location' in req.headers)
+        cookie = list(req._cookieCache.values())[0][0]
 
         # The URL should have the cookie segment in it and the correct path segments at the end
-        self.assertEquals(req.headers['location'],
+        self.assertEqual(req.headers['location'],
             'http://fake.com%s/%s/xxx/yyy/' % (self.getGuardPath(), guard.SESSION_KEY+cookie, ))
 
         # Now, let's follow the redirect
         req = req.followRedirect()
         # Our session should now be set up and we will be redirected to our final destination
-        self.assertEquals(req.headers['location'].split('?')[0],
+        self.assertEqual(req.headers['location'].split('?')[0],
             'http://fake.com%s/xxx/yyy/' % self.getGuardPath())
 
         # Let's follow the redirect to the final page
         req = req.followRedirect()
-        self.failIf(req.headers.has_key('location'))
+        self.assertFalse('location' in req.headers)
 
         # We should have the final resource, which is an anonymous resource
-        self.assertEquals(req.written.getvalue(), "No")
+        self.assertEqual(req.written.getvalue(), "No")
 
 
     def test_sessionInit_noCookies(self):
@@ -352,23 +352,23 @@ class GuardTestFuncs:
         # is a cookie being set and a redirect being issued to the session url
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath(), requestClass=FakeHTTPRequest_noCookies)
         # The redirect is set immediately and should have a path segment at the beginning matching our session id
-        self.failUnless(req.headers.has_key('location'))
+        self.assertTrue('location' in req.headers)
 
         # The URL should have the session id segment in it and the correct path segments at the end
         location = req.headers['location']
         prefix = 'http://fake.com%s/%s' % (self.getGuardPath(), guard.SESSION_KEY)
         suffix = '/xxx/yyy/'
-        self.failUnless(location.startswith(prefix))
-        self.failUnless(location.endswith(suffix))
+        self.assertTrue(location.startswith(prefix))
+        self.assertTrue(location.endswith(suffix))
         for c in location[len(prefix):-len(suffix)]:
-            self.failUnless(c in '0123456789abcdef')
+            self.assertTrue(c in '0123456789abcdef')
 
         # Now, let's follow the redirect
         req = req.followRedirect()
-        self.failIf(req.headers.has_key('location'))
+        self.assertFalse('location' in req.headers)
 
         # We should have the final resource, which is an anonymous resource
-        self.assertEquals(req.written.getvalue(), "No")
+        self.assertEqual(req.written.getvalue(), "No")
 
 
     def testUsernamePassword(self):
@@ -378,18 +378,18 @@ class GuardTestFuncs:
 
         # Check the anonymous page
         req = chan.makeFakeRequest('%s/' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "No")
+        self.assertEqual(req.written.getvalue(), "No")
 
         # Check the logged in page
         req = chan.makeFakeRequest('%s/__login__/?username=test&password=test' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "Yes")
+        self.assertEqual(req.written.getvalue(), "Yes")
 
         # Log out
         chan.makeFakeRequest("%s/__logout__" % self.getGuardPath()).followRedirect()
 
         # Get the anonymous page again
         k = chan.makeFakeRequest("%s/" % self.getGuardPath())
-        self.assertEquals(k.written.getvalue(), "No")
+        self.assertEqual(k.written.getvalue(), "No")
 
 
     def testLoginWithNoSession(self):
@@ -398,7 +398,7 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
 
         req = chan.makeFakeRequest('%s/__login__/?username=test&password=test' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "Yes")
+        self.assertEqual(req.written.getvalue(), "Yes")
 
 
     def test_sessionNegotiationSavesRequestParameters(self):
@@ -416,7 +416,7 @@ class GuardTestFuncs:
 
         request = channel.makeFakeRequest(
             '%s/?foo=1&bar=2' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(request.written.getvalue(), '')
+        self.assertEqual(request.written.getvalue(), '')
         self.assertEqual(
             renders, [({'foo': ['1'], 'bar': ['2']},
                        None,
@@ -458,7 +458,7 @@ class GuardTestFuncs:
             self.getGuardPath() + '/__login__?username=test&password=test')
         request = request.followAllRedirects()
 
-        self.assertEquals(request.written.getvalue(), '')
+        self.assertEqual(request.written.getvalue(), '')
         self.assertEqual(
             renders, [({'foo': ['1'], 'bar': ['2']},
                        None,
@@ -491,7 +491,7 @@ class GuardTestFuncs:
             self.getGuardPath() + '/__login__?username=test&password=test')
         request = request.followAllRedirects()
 
-        self.assertEquals(request.written.getvalue(), '')
+        self.assertEqual(request.written.getvalue(), '')
         self.assertEqual(
             renders, [({'username': ['test'], 'password': ['test']},
                        None,
@@ -507,16 +507,16 @@ class GuardTestFuncs:
 
         req = chan.makeFakeRequest('%s/' % self.getGuardPath(), requestClass=FakeHTTPRequest_noCookies).followAllRedirects()
         # We should have the final resource, which is an anonymous resource
-        self.assertEquals(req.written.getvalue(), "No")
+        self.assertEqual(req.written.getvalue(), "No")
 
         # now try requesting just the guard path
-        self.failUnless(req.path.startswith('%s/%s' % (self.getGuardPath(), guard.SESSION_KEY)))
-        self.failUnless(req.path.endswith('/'))
+        self.assertTrue(req.path.startswith('%s/%s' % (self.getGuardPath(), guard.SESSION_KEY)))
+        self.assertTrue(req.path.endswith('/'))
         req = chan.makeFakeRequest(req.path[:-1], requestClass=FakeHTTPRequest_noCookies).followAllRedirects()
 
         # it should work just as well as with the slash
         # (not actually the same page, but SillyPage always says the same thing here)
-        self.assertEquals(req.written.getvalue(), "No")
+        self.assertEqual(req.written.getvalue(), "No")
 
     def testTrailingSlashMatters_noCookies(self):
         class TrailingSlashPage(rend.Page):
@@ -548,15 +548,15 @@ class GuardTestFuncs:
 
         req = chan.makeFakeRequest('%s/' % self.getGuardPath(), requestClass=FakeHTTPRequest_noCookies).followAllRedirects()
         # We should have the final resource, which is an anonymous resource
-        self.assertEquals(req.written.getvalue(), "Anonymous %s/" % self.getGuardPath())
+        self.assertEqual(req.written.getvalue(), "Anonymous %s/" % self.getGuardPath())
 
         # now try requesting just the guard path
-        self.failUnless(req.path.startswith('%s/%s' % (self.getGuardPath(), guard.SESSION_KEY)))
-        self.failUnless(req.path.endswith('/'))
+        self.assertTrue(req.path.startswith('%s/%s' % (self.getGuardPath(), guard.SESSION_KEY)))
+        self.assertTrue(req.path.endswith('/'))
         req = chan.makeFakeRequest(req.path[:-1], requestClass=FakeHTTPRequest_noCookies).followAllRedirects()
 
         # it should no longer have the trailing slash
-        self.assertEquals(req.written.getvalue(), "Anonymous %s" % self.getGuardPath())
+        self.assertEqual(req.written.getvalue(), "Anonymous %s" % self.getGuardPath())
 
     def testTrailingSlashMatters_withCookies(self):
         # omitting the trailing slash when not using session keys can
@@ -593,21 +593,21 @@ class GuardTestFuncs:
 
         req = chan.makeFakeRequest('%s/' % self.getGuardPath()).followAllRedirects()
         # We should have the final resource, which is an anonymous resource
-        self.assertEquals(req.written.getvalue(), "Anonymous %s/" % self.getGuardPath())
+        self.assertEqual(req.written.getvalue(), "Anonymous %s/" % self.getGuardPath())
 
         req = chan.makeFakeRequest('%s' % self.getGuardPath()).followAllRedirects()
         # We should have the final resource, which is an anonymous resource
-        self.assertEquals(req.written.getvalue(), "Anonymous %s" % self.getGuardPath())
+        self.assertEqual(req.written.getvalue(), "Anonymous %s" % self.getGuardPath())
 
     def testPlainTextCookie(self):
         """Cookies from non-SSL sites have no secure attribute."""
         p = self.createPortal()
         chan = self.createGuard(p)
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath())
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
-        cookie, a, kw = req._cookieCache.values()[0]
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
+        cookie, a, kw = list(req._cookieCache.values())[0]
         secure = kw.get('secure', None)
-        self.failIf(secure)
+        self.assertFalse(secure)
 
     def testPlainTextCookie_evenWithSecureCookies(self):
         """Cookies from non-SSL sites have no secure attribute, even if secureCookie is true."""
@@ -616,10 +616,10 @@ class GuardTestFuncs:
         gu = getGuard(chan)
         gu.secureCookies = False
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath())
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
-        cookie, a, kw = req._cookieCache.values()[0]
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
+        cookie, a, kw = list(req._cookieCache.values())[0]
         secure = kw.get('secure', None)
-        self.failIf(secure)
+        self.assertFalse(secure)
 
     def testSecureCookie_secureCookies(self):
         """Cookies from SSL sites have secure=True."""
@@ -627,10 +627,10 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath(),
                                    requestClass=FakeHTTPRequest_forceSSL)
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
-        cookie, a, kw = req._cookieCache.values()[0]
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
+        cookie, a, kw = list(req._cookieCache.values())[0]
         secure = kw.get('secure', None)
-        self.failUnless(secure)
+        self.assertTrue(secure)
 
     def testSecureCookie_noSecureCookies(self):
         """Cookies from SSL sites do not have secure=True if secureCookies is false."""
@@ -640,10 +640,10 @@ class GuardTestFuncs:
         gu.secureCookies = False
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath(),
                                    requestClass=FakeHTTPRequest_forceSSL)
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
-        cookie, a, kw = req._cookieCache.values()[0]
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
+        cookie, a, kw = list(req._cookieCache.values())[0]
         secure = kw.get('secure', None)
-        self.failIf(secure)
+        self.assertFalse(secure)
 
     def testPersistentCookie_persistentCookies(self):
         """Cookies from sites are saved to disk because SessionWrapper.persistentCookies=True."""
@@ -653,8 +653,8 @@ class GuardTestFuncs:
         gu.persistentCookies = True
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath(),
                                    requestClass=FakeHTTPRequest)
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
-        cookie, a, kw = req._cookieCache.values()[0]
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
+        cookie, a, kw = list(req._cookieCache.values())[0]
         expires = kw.get('expires', None)
         self.failIfIdentical(expires, None)
 
@@ -664,8 +664,8 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath(),
                                    requestClass=FakeHTTPRequest)
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
-        cookie, a, kw = req._cookieCache.values()[0]
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
+        cookie, a, kw = list(req._cookieCache.values())[0]
         expires = kw.get('expires', None)
         self.failUnlessIdentical(expires, None)
 
@@ -676,13 +676,13 @@ class GuardTestFuncs:
         p = self.createPortal()
         chan = self.createGuard(p)
         req = chan.makeFakeRequest('%s/xxx/yyy/' % self.getGuardPath())
-        self.assertEquals( len(req._cookieCache.values()), 1, "Bad number of cookies in response.")
-        cookie, a, kw = req._cookieCache.values()[0]
+        self.assertEqual( len(list(req._cookieCache.values())), 1, "Bad number of cookies in response.")
+        cookie, a, kw = list(req._cookieCache.values())[0]
         path = kw.get('path', None)
         wanted = self.getGuardPath()
         if wanted == '':
             wanted = '/'
-        self.failUnlessEqual(path, wanted)
+        self.assertEqual(path, wanted)
 
 
     def test_defaultCookieDomain(self):
@@ -692,7 +692,7 @@ class GuardTestFuncs:
         portal = self.createPortal()
         channel = self.createGuard(portal)
         request = channel.makeFakeRequest('%s/abc' % (self.getGuardPath(),))
-        cookie, args, kwargs = request._cookieCache.values()[0]
+        cookie, args, kwargs = list(request._cookieCache.values())[0]
         self.assertEqual(kwargs['domain'], None)
 
 
@@ -714,7 +714,7 @@ class GuardTestFuncs:
         channel = self.createGuard(portal)
 
         request = channel.makeFakeRequest('%s/abc' % (self.getGuardPath(),))
-        cookie, args, kwargs = request._cookieCache.values()[0]
+        cookie, args, kwargs = list(request._cookieCache.values())[0]
         self.assertEqual(kwargs['domain'], 'example.com')
         self.assertEqual(requests, [request])
 
@@ -725,8 +725,8 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
 
         req = chan.makeFakeRequest('%s/__login__/sub/path?username=test&password=test' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "Yes")
-        self.assertEquals(req.path, '%s/sub/path' % self.getGuardPath())
+        self.assertEqual(req.written.getvalue(), "Yes")
+        self.assertEqual(req.path, '%s/sub/path' % self.getGuardPath())
 
     def testLoginExtraPath_withSlash(self):
         p = self.createPortal()
@@ -734,8 +734,8 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
 
         req = chan.makeFakeRequest('%s/__login__/sub/path/?username=test&password=test' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "Yes")
-        self.assertEquals(req.path, '%s/sub/path/' % self.getGuardPath())
+        self.assertEqual(req.written.getvalue(), "Yes")
+        self.assertEqual(req.path, '%s/sub/path/' % self.getGuardPath())
 
     def testLogoutExtraPath(self):
         p = self.createPortal()
@@ -743,12 +743,12 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
 
         req = chan.makeFakeRequest('%s/__login__?username=test&password=test' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "Yes")
+        self.assertEqual(req.written.getvalue(), "Yes")
 
         # Log out
         req2 = chan.makeFakeRequest("%s/__logout__/sub/path" % self.getGuardPath()).followRedirect()
-        self.assertEquals(req2.written.getvalue(), "No")
-        self.assertEquals(req2.path, '%s/sub/path' % self.getGuardPath())
+        self.assertEqual(req2.written.getvalue(), "No")
+        self.assertEqual(req2.path, '%s/sub/path' % self.getGuardPath())
 
     def testLogoutExtraPath_withSlash(self):
         p = self.createPortal()
@@ -756,12 +756,12 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
 
         req = chan.makeFakeRequest('%s/__login__?username=test&password=test' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "Yes")
+        self.assertEqual(req.written.getvalue(), "Yes")
 
         # Log out
         req2 = chan.makeFakeRequest("%s/__logout__/sub/path/" % self.getGuardPath()).followRedirect()
-        self.assertEquals(req2.written.getvalue(), "No")
-        self.assertEquals(req2.path, '%s/sub/path/' % self.getGuardPath())
+        self.assertEqual(req2.written.getvalue(), "No")
+        self.assertEqual(req2.path, '%s/sub/path/' % self.getGuardPath())
 
     def testGetLoggedInRoot_getLogin(self):
         p = self.createPortal(realmFactory=GetLoggedInRealm)
@@ -769,7 +769,7 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
 
         req = chan.makeFakeRequest('%s/__login__?username=test&password=test' % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), "GetLoggedInAvatar")
+        self.assertEqual(req.written.getvalue(), "GetLoggedInAvatar")
 
     def testGetLoggedInRoot_httpAuthLogin(self):
 
@@ -778,8 +778,8 @@ class GuardTestFuncs:
         chan = self.createGuard(p)
         for x in range(4):
             req = chan.makeFakeRequest('%s/' % self.getGuardPath(), "test", "test")
-            self.assertEquals(req.written.getvalue(), "GetLoggedInAvatar")
-        self.assertEquals(len(self.sessions),1)
+            self.assertEqual(req.written.getvalue(), "GetLoggedInAvatar")
+        self.assertEqual(len(self.sessions),1)
 
     def testErrorPage_httpAuth(self):
         """Failed HTTP Auth results in a 403 error."""
@@ -790,13 +790,13 @@ class GuardTestFuncs:
 
         req = chan.makeFakeRequest('%s' % self.getGuardPath(),
                                    "test", "invalid-password")
-        self.assertEquals(req.headers.get('location', None), None)
-        self.assertEquals(req.code, 403)
-        self.assertEquals(req.written.getvalue(),
+        self.assertEqual(req.headers.get('location', None), None)
+        self.assertEqual(req.code, 403)
+        self.assertEqual(req.written.getvalue(),
                           '<html><head><title>Forbidden</title></head>'
                           +'<body><h1>Forbidden</h1>Request was forbidden.'
                           +'</body></html>')
-        self.assertEquals(req.path, self.getGuardPath())
+        self.assertEqual(req.path, self.getGuardPath())
 
     def testErrorPage_httpAuth_deep(self):
         """Failed HTTP Auth results in a 403 error."""
@@ -807,13 +807,13 @@ class GuardTestFuncs:
 
         req = chan.makeFakeRequest('%s/quux/thud' % self.getGuardPath(),
                                    "test", "invalid-password")
-        self.assertEquals(req.headers.get('location', None), None)
-        self.assertEquals(req.code, 403)
-        self.assertEquals(req.written.getvalue(),
+        self.assertEqual(req.headers.get('location', None), None)
+        self.assertEqual(req.code, 403)
+        self.assertEqual(req.written.getvalue(),
                           '<html><head><title>Forbidden</title></head>'
                           +'<body><h1>Forbidden</h1>Request was forbidden.'
                           +'</body></html>')
-        self.assertEquals(req.path, '%s/quux/thud' % self.getGuardPath())
+        self.assertEqual(req.path, '%s/quux/thud' % self.getGuardPath())
 
     def testErrorPage_getLogin(self):
         """Failed normal login results in anonymous view of the same page."""
@@ -825,11 +825,11 @@ class GuardTestFuncs:
         req = chan.makeFakeRequest(
             '%s/__login__?username=test&password=invalid-password'
             % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), 'No')
+        self.assertEqual(req.written.getvalue(), 'No')
         wanted = self.getGuardPath()
         if wanted == '':
             wanted = '/'
-        self.assertEquals(req.path, wanted)
+        self.assertEqual(req.path, wanted)
 
     def testErrorPage_getLogin_deep(self):
         """Failed normal login results in anonymous view of the same page."""
@@ -841,8 +841,8 @@ class GuardTestFuncs:
         req = chan.makeFakeRequest(
             '%s/__login__/quux/thud?username=test&password=invalid-password'
             % self.getGuardPath()).followAllRedirects()
-        self.assertEquals(req.written.getvalue(), 'No')
-        self.assertEquals(req.path, '%s/quux/thud' % self.getGuardPath())
+        self.assertEqual(req.written.getvalue(), 'No')
+        self.assertEqual(req.path, '%s/quux/thud' % self.getGuardPath())
 
 
 class ParentPage(rend.Page):

--- a/nevow/test/test_howtolistings.py
+++ b/nevow/test/test_howtolistings.py
@@ -13,6 +13,7 @@ from nevow.testutil import renderLivePage, JavaScriptTestCase
 from nevow.athena import jsDeps, expose
 
 from nevow import plugins
+import imp
 
 
 class ExampleTestBase(object):
@@ -53,7 +54,7 @@ class ExampleTestBase(object):
         jsDeps._loadPlugins = True
         # Even more horrible!  nevow.plugins.__path__ needs to be recomputed
         # each time for the new value of sys.path.
-        reload(plugins)
+        imp.reload(plugins)
 
 
     def tearDown(self):
@@ -64,7 +65,7 @@ class ExampleTestBase(object):
         sys.modules.clear()
         sys.modules.update(self.originalModules)
         sys.path[:] = self.originalPath
-        reload(plugins)
+        imp.reload(plugins)
 
 
 
@@ -83,7 +84,7 @@ class ExampleJavaScriptTestCase(JavaScriptTestCase):
         base.examplePath = self.examplePath
         try:
             base.setUp()
-        except SkipTest, e:
+        except SkipTest as e:
             result.startTest(self)
             result.addSkip(self, str(e))
             result.stopTest(self)
@@ -152,8 +153,8 @@ class Echo00(ExampleTestBase, TestCase):
         eb = EchoElement()
         echoed = []
         eb.callRemote = lambda method, message: echoed.append((method, message))
-        eb.say(u'HELLO... Hello... hello...')
-        self.assertEquals(echoed, [('addText', u'HELLO... Hello... hello...')])
+        eb.say('HELLO... Hello... hello...')
+        self.assertEqual(echoed, [('addText', 'HELLO... Hello... hello...')])
 
 
 
@@ -205,8 +206,8 @@ class RenderAndChat01(ExampleTestBase, TestCase):
         from chatthing.chatterbox import ChatterElement, ChatRoom
         cb = ChatterElement(ChatRoom())
         setUsername = expose.get(cb, 'setUsername')
-        setUsername(u'jethro')
-        self.assertIdentical(u'jethro', cb.username)
+        setUsername('jethro')
+        self.assertIdentical('jethro', cb.username)
 
 
     def test_loginThenWall(self):
@@ -220,14 +221,14 @@ class RenderAndChat01(ExampleTestBase, TestCase):
         cr = ChatRoom()
         user1 = cr.makeChatter()
         user1.wall = lambda msg: jethroHeard.append(msg)
-        user1.setUsername(u'jethro')
+        user1.setUsername('jethro')
         user2 = cr.makeChatter()
         user2.wall = lambda msg: cletusHeard.append(msg)
-        user2.setUsername(u'cletus')
-        self.assertEquals(jethroHeard,
-                          [u' * user jethro has joined the room',
-                           u' * user cletus has joined the room'])
-        self.assertEquals(cletusHeard, [u' * user cletus has joined the room'])
+        user2.setUsername('cletus')
+        self.assertEqual(jethroHeard,
+                          [' * user jethro has joined the room',
+                           ' * user cletus has joined the room'])
+        self.assertEqual(cletusHeard, [' * user cletus has joined the room'])
 
 
     def test_sayThenHear(self):
@@ -239,18 +240,18 @@ class RenderAndChat01(ExampleTestBase, TestCase):
         cr = ChatRoom()
         user1 = cr.makeChatter()
         user1.wall = lambda msg: msg
-        user1.setUsername(u'jethro')
+        user1.setUsername('jethro')
         user2 = cr.makeChatter()
         user2.wall = lambda msg: msg
-        user2.setUsername(u'cletus')
+        user2.setUsername('cletus')
         jethroHeard = []
         cletusHeard = []
         user1.hear = lambda who, what: jethroHeard.append((who,what))
         user2.hear = lambda who, what: cletusHeard.append((who,what))
         say = expose.get(user1, 'say')
-        say(u'Hey, Cletus!')
-        self.assertEquals(jethroHeard, cletusHeard)
-        self.assertEquals(cletusHeard, [(u'jethro', u'Hey, Cletus!')])
+        say('Hey, Cletus!')
+        self.assertEqual(jethroHeard, cletusHeard)
+        self.assertEqual(cletusHeard, [('jethro', 'Hey, Cletus!')])
 
 
     def test_wallTellsClient(self):
@@ -262,8 +263,8 @@ class RenderAndChat01(ExampleTestBase, TestCase):
         cb = ChatRoom().makeChatter()
         heard = []
         cb.callRemote = lambda method, msg: heard.append((method, msg))
-        cb.wall(u'Message for everyone...')
-        self.assertEquals(heard, [('displayMessage', u'Message for everyone...')])
+        cb.wall('Message for everyone...')
+        self.assertEqual(heard, [('displayMessage', 'Message for everyone...')])
 
     def test_hearTellsClient(self):
         """
@@ -274,6 +275,6 @@ class RenderAndChat01(ExampleTestBase, TestCase):
         cb = ChatRoom().makeChatter()
         heard = []
         cb.callRemote = lambda method, who, what: heard.append((method, who, what))
-        cb.hear(u'Hello', u'Chat')
-        self.assertEquals(heard, [('displayUserMessage', u'Hello', u'Chat')])
+        cb.hear('Hello', 'Chat')
+        self.assertEqual(heard, [('displayUserMessage', 'Hello', 'Chat')])
 

--- a/nevow/test/test_i18n.py
+++ b/nevow/test/test_i18n.py
@@ -1,7 +1,7 @@
 from zope.interface import implements
 
 from twisted.trial import unittest
-from cStringIO import StringIO
+from io import StringIO
 from nevow import inevow, flat, context, tags, loaders, rend
 from nevow import i18n
 from nevow.testutil import FakeRequest
@@ -11,7 +11,7 @@ def mockTranslator(s, languages=None, domain=None):
     if domain is not None:
         args['domain'] = domain
     return 'MOCK(%s)[%s]' % (', '.join(['%s=%r' % (k,v)
-                                        for k,v in args.items()]),
+                                        for k,v in list(args.items())]),
                              s)
 
 class Misc(unittest.TestCase):
@@ -21,13 +21,13 @@ class Misc(unittest.TestCase):
     def test_simple_flat(self):
         s = i18n._('foo')
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, 'foo')
+        self.assertEqual(r, 'foo')
 
     def test_translator(self):
         _ = i18n.Translator(translator=mockTranslator)
         s = _('foo')
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, 'MOCK()[foo]')
+        self.assertEqual(r, 'MOCK()[foo]')
 
 class Config(unittest.TestCase):
     def test_remember(self):
@@ -41,13 +41,13 @@ class Domain(unittest.TestCase):
                             domain='bar')
         s = _('foo')
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "MOCK(domain='bar')[foo]")
+        self.assertEqual(r, "MOCK(domain='bar')[foo]")
 
     def test_runTime(self):
         _ = i18n.Translator(translator=mockTranslator)
         s = _('foo', domain='baz')
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "MOCK(domain='baz')[foo]")
+        self.assertEqual(r, "MOCK(domain='baz')[foo]")
 
     def test_context(self):
         _ = i18n.Translator(translator=mockTranslator)
@@ -56,7 +56,7 @@ class Domain(unittest.TestCase):
         ctx.remember(cfg)
         s = _('foo')
         r = flat.ten.flatten(s, ctx)
-        self.assertEquals(r, "MOCK(domain='thud')[foo]")
+        self.assertEqual(r, "MOCK(domain='thud')[foo]")
 
     def test_runTime_beats_all(self):
         _ = i18n.Translator(translator=mockTranslator,
@@ -66,7 +66,7 @@ class Domain(unittest.TestCase):
         ctx.remember(cfg)
         s = _('foo', domain='baz')
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "MOCK(domain='baz')[foo]")
+        self.assertEqual(r, "MOCK(domain='baz')[foo]")
 
 
     def test_classInit_beats_context(self):
@@ -77,14 +77,14 @@ class Domain(unittest.TestCase):
         ctx.remember(cfg)
         s = _('foo')
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "MOCK(domain='baz')[foo]")
+        self.assertEqual(r, "MOCK(domain='baz')[foo]")
 
 class Format(unittest.TestCase):
     def test_simple(self):
         _ = i18n.Translator(translator=mockTranslator)
         s = _('foo %s') % 'bar'
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "MOCK()[foo bar]")
+        self.assertEqual(r, "MOCK()[foo bar]")
 
     def test_multiple(self):
         _ = i18n.Translator(translator=mockTranslator)
@@ -92,7 +92,7 @@ class Format(unittest.TestCase):
         s = s % 'bar %s'
         s = s % 'baz'
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "MOCK()[foo bar baz]")
+        self.assertEqual(r, "MOCK()[foo bar baz]")
 
 
 
@@ -101,7 +101,7 @@ class Languages(unittest.TestCase):
         request = FakeRequest(headers={})
         ctx = context.RequestContext(tag=request)
         r = inevow.ILanguages(ctx)
-        self.assertEquals(r, [])
+        self.assertEqual(r, [])
 
     def test_oneLanguage(self):
         request = FakeRequest(headers={
@@ -109,7 +109,7 @@ class Languages(unittest.TestCase):
             })
         ctx = context.RequestContext(tag=request)
         r = inevow.ILanguages(ctx)
-        self.assertEquals(r, ['fo'])
+        self.assertEqual(r, ['fo'])
 
     def test_multipleLanguages(self):
         request = FakeRequest(headers={
@@ -117,7 +117,7 @@ class Languages(unittest.TestCase):
             })
         ctx = context.RequestContext(tag=request)
         r = inevow.ILanguages(ctx)
-        self.assertEquals(r, ['fo', 'ba', 'th'])
+        self.assertEqual(r, ['fo', 'ba', 'th'])
 
     def test_quality_simple(self):
         request = FakeRequest(headers={
@@ -125,7 +125,7 @@ class Languages(unittest.TestCase):
             })
         ctx = context.RequestContext(tag=request)
         r = inevow.ILanguages(ctx)
-        self.assertEquals(r, ['fo'])
+        self.assertEqual(r, ['fo'])
 
     def test_quality_sort(self):
         request = FakeRequest(headers={
@@ -133,7 +133,7 @@ class Languages(unittest.TestCase):
             })
         ctx = context.RequestContext(tag=request)
         r = inevow.ILanguages(ctx)
-        self.assertEquals(r, ['xy', 'fo', 'ba'])
+        self.assertEqual(r, ['xy', 'fo', 'ba'])
 
     def test_quality_invalid_notQ(self):
         request = FakeRequest(headers={
@@ -141,7 +141,7 @@ class Languages(unittest.TestCase):
             })
         ctx = context.RequestContext(tag=request)
         r = inevow.ILanguages(ctx)
-        self.assertEquals(r, ['ba', 'fo'])
+        self.assertEqual(r, ['ba', 'fo'])
 
     def test_quality_invalid_notFloat(self):
         request = FakeRequest(headers={
@@ -149,7 +149,7 @@ class Languages(unittest.TestCase):
             })
         ctx = context.RequestContext(tag=request)
         r = inevow.ILanguages(ctx)
-        self.assertEquals(r, ['ba', 'fo'])
+        self.assertEqual(r, ['ba', 'fo'])
 
 class Render(unittest.TestCase):
     def makePage(self, content):
@@ -172,15 +172,15 @@ class Render(unittest.TestCase):
 
     def test_empty(self):
         return self.makePage(['']).addCallback(
-            lambda r: self.assertEquals(r, 'MOCK()[]'))
+            lambda r: self.assertEqual(r, 'MOCK()[]'))
 
     def test_simple(self):
         return self.makePage(['foo']).addCallback(
-            lambda r: self.assertEquals(r, 'MOCK()[foo]'))
+            lambda r: self.assertEqual(r, 'MOCK()[foo]'))
 
     def test_stan(self):
         return self.makePage([tags.p['You should really avoid tags in i18n input.']]).addCallback(
-            lambda r: self.assertEquals(r, 'MOCK()[<p>You should really avoid tags in i18n input.</p>]'))
+            lambda r: self.assertEqual(r, 'MOCK()[<p>You should really avoid tags in i18n input.</p>]'))
 
 class InterpolateTests:
     def test_mod_string(self):
@@ -188,7 +188,7 @@ class InterpolateTests:
                    'foo bar')
 
     def test_mod_unicode(self):
-        self.check('foo %s', u'bar',
+        self.check('foo %s', 'bar',
                    'foo bar')
 
     def test_mod_int(self):
@@ -255,7 +255,7 @@ class InterpolateMixin:
         self._ = i18n.Translator(translator=mockTranslator)
 
     def mangle(self, s):
-        raise NotImplementedError, 'override mangle somewhere'
+        raise NotImplementedError('override mangle somewhere')
 
     def check(self, fmt, args, *wants):
         got = self.mangle(self._(fmt) % args)
@@ -296,24 +296,24 @@ class UNGettext(unittest.TestCase):
     def test_simple_flat_one(self):
         s = i18n.ungettext('%d foo', '%d foos', 1)
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, '%d foo')
+        self.assertEqual(r, '%d foo')
 
     def test_simple_flat_many(self):
         s = i18n.ungettext('%d foo', '%d foos', 42)
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, '%d foos')
+        self.assertEqual(r, '%d foos')
 
     def test_simple_flat_many(self):
         s = i18n.ungettext('%d foo', '%d foos', 42)
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, '%d foos')
+        self.assertEqual(r, '%d foos')
 
     def test_format_one(self):
         s = i18n.ungettext('%d foo', '%d foos', 1) % 1
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "1 foo")
+        self.assertEqual(r, "1 foo")
 
     def test_format_many(self):
         s = i18n.ungettext('%d foo', '%d foos', 42) % 42
         r = flat.ten.flatten(s, None)
-        self.assertEquals(r, "42 foos")
+        self.assertEqual(r, "42 foos")

--- a/nevow/test/test_i18n.py
+++ b/nevow/test/test_i18n.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.trial import unittest
 from io import StringIO

--- a/nevow/test/test_json.py
+++ b/nevow/test/test_json.py
@@ -5,7 +5,7 @@
 Tests for L{nevow.json}.
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from nevow.inevow import IAthenaTransportable
 from nevow import json, rend, page, loaders, tags, athena, testutil
@@ -264,12 +264,12 @@ class JavascriptObjectNotationTestCase(unittest.TestCase):
         L{IAthenaTransportable.getInitialArguments} when passed an object which
         can be adapted to L{IAthenaTransportable}.
         """
+        @implementer(IAthenaTransportable)
         class Transportable(object):
             """
             Completely parameterized L{IAthenaTransportable} implementation so
             different data can be easily tested.
             """
-            implements(IAthenaTransportable)
 
             def __init__(self, jsClass, initialArgs):
                 self.jsClass = jsClass

--- a/nevow/test/test_json.py
+++ b/nevow/test/test_json.py
@@ -21,31 +21,31 @@ TEST_OBJECTS = [
     [0],
     [0, 1, 2],
     [None, 1, 2],
-    [None, u'one', 2],
-    [True, False, u'string', 10],
+    [None, 'one', 2],
+    [True, False, 'string', 10],
     [[1, 2], [3, 4]],
     [[1.5, 2.5], [3.5, 4.5]],
-    [0, [1, 2], [u'hello'], [u'world'], [True, None, False]],
+    [0, [1, 2], ['hello'], ['world'], [True, None, False]],
     {},
-    {u'foo': u'bar'},
-    {u'foo': None},
-    {u'bar': True},
-    {u'baz': [1, 2, 3]},
-    {u'quux': {u'bar': u'foo'}},
+    {'foo': 'bar'},
+    {'foo': None},
+    {'bar': True},
+    {'baz': [1, 2, 3]},
+    {'quux': {'bar': 'foo'}},
     ]
 
 TEST_STRINGLIKE_OBJECTS = [
-    u'',
-    u'string',
-    u'string with "embedded" quotes',
-    u"string with 'embedded' single-quotes",
-    u'string with \\"escaped embedded\\" quotes',
-    u"string with \\'escaped embedded\\' single-quotes",
-    u"string with backslashes\\\\",
-    u"string with trailing accented vowels: \xe1\xe9\xed\xf3\xfa\xfd\xff",
-    u"string with trailing control characters: \f\b\n\t\r",
-    u'string with high codepoint characters: \u0111\u2222\u3333\u4444\uffff',
-    u'string with very high codepoint characters: \U00011111\U00022222\U00033333\U00044444\U000fffff',
+    '',
+    'string',
+    'string with "embedded" quotes',
+    "string with 'embedded' single-quotes",
+    'string with \\"escaped embedded\\" quotes',
+    "string with \\'escaped embedded\\' single-quotes",
+    "string with backslashes\\\\",
+    "string with trailing accented vowels: \xe1\xe9\xed\xf3\xfa\xfd\xff",
+    "string with trailing control characters: \f\b\n\t\r",
+    'string with high codepoint characters: \u0111\u2222\u3333\u4444\uffff',
+    'string with very high codepoint characters: \U00011111\U00022222\U00033333\U00044444\U000fffff',
     ]
 
 
@@ -93,7 +93,7 @@ class JavascriptObjectNotationTestCase(unittest.TestCase):
         for struct in TEST_OBJECTS:
             bytes = json.serialize(struct)
             unstruct = json.parse(bytes)
-            self.assertEquals(
+            self.assertEqual(
                 unstruct, struct,
                 "Failed to roundtrip %r: %r (through %r)" % (
                     struct, unstruct, bytes))
@@ -103,7 +103,7 @@ class JavascriptObjectNotationTestCase(unittest.TestCase):
         """
         C{undefined} is parsed as Python C{None}.
         """
-        self.assertEquals(None, json.parse(b'undefined'))
+        self.assertEqual(None, json.parse(b'undefined'))
 
 
     def testStringlikeRountrip(self):
@@ -112,8 +112,8 @@ class JavascriptObjectNotationTestCase(unittest.TestCase):
             unstruct = json.parse(bytes)
             failMsg = "Failed to roundtrip %r: %r (through %r)" % (
                     struct, unstruct, bytes)
-            self.assertEquals(unstruct, struct, failMsg)
-            self.assert_(isinstance(unstruct, unicode), failMsg)
+            self.assertEqual(unstruct, struct, failMsg)
+            self.assertTrue(isinstance(unstruct, str), failMsg)
 
 
     def test_lineTerminators(self):
@@ -127,30 +127,30 @@ class JavascriptObjectNotationTestCase(unittest.TestCase):
         handle them properly.
         """
         # These are the four line terminators currently in Unicode.
-        self.assertEqual('"\\r"', json.serialize(u"\r"))
-        self.assertEqual('"\\n"', json.serialize(u"\n"))
-        self.assertEqual('"\\u2028"', json.serialize(u"\u2028"))
-        self.assertEqual('"\\u2029"', json.serialize(u"\u2029"))
+        self.assertEqual('"\\r"', json.serialize("\r"))
+        self.assertEqual('"\\n"', json.serialize("\n"))
+        self.assertEqual('"\\u2028"', json.serialize("\u2028"))
+        self.assertEqual('"\\u2029"', json.serialize("\u2029"))
 
 
     def testScientificNotation(self):
-        self.assertEquals(json.parse('1e10'), 10**10)
-        self.assertEquals(json.parse('1e0'), 1)
+        self.assertEqual(json.parse('1e10'), 10**10)
+        self.assertEqual(json.parse('1e0'), 1)
 
 
     def testHexEscapedCodepoints(self):
-        self.assertEquals(
+        self.assertEqual(
             json.parse('"\\xe1\\xe9\\xed\\xf3\\xfa\\xfd"'),
-            u"\xe1\xe9\xed\xf3\xfa\xfd")
+            "\xe1\xe9\xed\xf3\xfa\xfd")
 
     def testEscapedControls(self):
-        self.assertEquals(
+        self.assertEqual(
             json.parse('"\\f\\b\\n\\t\\r"'),
-            u"\f\b\n\t\r")
+            "\f\b\n\t\r")
 
 
     def _rendererTest(self, cls):
-        self.assertEquals(
+        self.assertEqual(
             json.serialize(
                 cls(
                     docFactory=loaders.stan(tags.p['Hello, world.']))),
@@ -276,18 +276,18 @@ class JavascriptObjectNotationTestCase(unittest.TestCase):
                 self.getInitialArguments = lambda: initialArgs
 
         self.assertEqual(
-            json.serialize(Transportable(u"Foo", ())),
+            json.serialize(Transportable("Foo", ())),
             "(new Foo())")
         self.assertEqual(
-            json.serialize(Transportable(u"Bar", (None,))),
+            json.serialize(Transportable("Bar", (None,))),
             "(new Bar(null))")
         self.assertEqual(
-            json.serialize(Transportable(u"Baz.Quux", (1, 2))),
+            json.serialize(Transportable("Baz.Quux", (1, 2))),
             "(new Baz.Quux(1,2))")
 
         # The style of the quotes in this assertion is basically irrelevant.
         # If, for some reason, the serializer changes to use ' instead of ",
         # there's no reason not to change this test to reflect that. -exarkun
         self.assertEqual(
-            json.serialize(Transportable(u"Quux", (u"Foo",))),
+            json.serialize(Transportable("Quux", ("Foo",))),
             '(new Quux("Foo"))')

--- a/nevow/test/test_later.py
+++ b/nevow/test/test_later.py
@@ -43,29 +43,29 @@ class LaterRenderTest(RenderHelper):
 
     def test_deferredSupport(self):
         req = self.renderIt()
-        self.assertEquals(req.v, '<html>Hello ')
+        self.assertEqual(req.v, '<html>Hello ')
         self.d.callback("world")
-        self.assertEquals(req.v, '<html>Hello world')
+        self.assertEqual(req.v, '<html>Hello world')
         self.d2.callback(".")
-        self.assertEquals(req.v, '<html>Hello world.</html>')
+        self.assertEqual(req.v, '<html>Hello world.</html>')
 
 
     def test_deferredSupport2(self):
         req = self.renderIt()
-        self.assertEquals(req.v, '<html>Hello ')
+        self.assertEqual(req.v, '<html>Hello ')
         self.d2.callback(".")
-        self.assertEquals(req.v, '<html>Hello ')
+        self.assertEqual(req.v, '<html>Hello ')
         self.d.callback("world")
-        self.assertEquals(req.v, '<html>Hello world.</html>')
+        self.assertEqual(req.v, '<html>Hello world.</html>')
 
     def test_deferredSupport3(self):
         self.r.buffered = True
         req = self.renderIt()
-        self.assertEquals(req.v, '')
+        self.assertEqual(req.v, '')
         self.d.callback("world")
-        self.assertEquals(req.v, '')
+        self.assertEqual(req.v, '')
         self.d2.callback(".")
-        self.assertEquals(req.v, '<html>Hello world.</html>')
+        self.assertEqual(req.v, '<html>Hello world.</html>')
 
     def test_renderNestedDeferredCallables(self):
         """
@@ -84,7 +84,7 @@ class LaterRenderTest(RenderHelper):
         out = []
         d = twist.deferflatten(render_outer, ctx, out.append)
         def flattened(ign):
-            self.assertEquals(out, [''])
+            self.assertEqual(out, [''])
         d.addCallback(flattened)
         return d
 
@@ -130,11 +130,11 @@ class LaterDataTest(RenderHelper):
 
     def test_deferredSupport(self):
         req = self.renderIt()
-        self.assertEquals(req.v, '')
+        self.assertEqual(req.v, '')
         self.d.callback("world")
-        self.assertEquals(req.v, '<html>Hello world and goodbye world')
+        self.assertEqual(req.v, '<html>Hello world and goodbye world')
         self.d2.callback(".")
-        self.assertEquals(req.v, '<html>Hello world and goodbye world.</html>')
+        self.assertEqual(req.v, '<html>Hello world and goodbye world.</html>')
 
 
 class SuperLaterDataTest(RenderHelper):
@@ -148,7 +148,7 @@ class SuperLaterDataTest(RenderHelper):
         doc.fillSlots('foo', defer.succeed(tags.span['Foo!!!']))
         self.r = rend.Page(docFactory=loaders.stan(doc))
         req = self.renderIt()
-        self.assertEquals(req.v, '<html><span>Foo!!!</span><span>Foo!!!</span></html>')
+        self.assertEqual(req.v, '<html><span>Foo!!!</span><span>Foo!!!</span></html>')
 
 
     def test_rendererCalledOnce(self):
@@ -167,4 +167,4 @@ class SuperLaterDataTest(RenderHelper):
                 return defer.succeed(recorder)
         self.r = RendererPage()
         req = self.renderIt()
-        self.assertEquals(req.v, '<html>1</html>')
+        self.assertEqual(req.v, '<html>1</html>')

--- a/nevow/test/test_loaders.py
+++ b/nevow/test/test_loaders.py
@@ -15,17 +15,17 @@ class TestDocFactories(unittest.TestCase):
 
     def _preprocessorTest(self, docFactory):
         def preprocessor(uncompiled):
-            self.assertEquals(len(uncompiled), 1)
+            self.assertEqual(len(uncompiled), 1)
             uncompiled = uncompiled[0]
-            self.assertEquals(uncompiled.tagName, 'div')
-            self.assertEquals(len(uncompiled.children), 2)
-            self.assertEquals(uncompiled.children[0].tagName, 'span')
-            self.assertEquals(uncompiled.children[0].children, ['Hello'])
-            self.assertEquals(uncompiled.children[1].tagName, 'span')
-            self.assertEquals(uncompiled.children[1].children, ['world'])
+            self.assertEqual(uncompiled.tagName, 'div')
+            self.assertEqual(len(uncompiled.children), 2)
+            self.assertEqual(uncompiled.children[0].tagName, 'span')
+            self.assertEqual(uncompiled.children[0].children, ['Hello'])
+            self.assertEqual(uncompiled.children[1].tagName, 'span')
+            self.assertEqual(uncompiled.children[1].children, ['world'])
             return t.div['goodbye.']
         doc = docFactory.load(preprocessors=[preprocessor])
-        self.assertEquals(doc, ['<div>goodbye.</div>'])
+        self.assertEqual(doc, ['<div>goodbye.</div>'])
 
 
     def test_stanPreprocessors(self):
@@ -41,7 +41,7 @@ class TestDocFactories(unittest.TestCase):
     def test_stan(self):
         doc = t.ul(id='nav')[t.li['one'], t.li['two'], t.li['three']]
         df = loaders.stan(doc)
-        self.assertEquals(df.load()[0], '<ul id="nav"><li>one</li><li>two</li><li>three</li></ul>')
+        self.assertEqual(df.load()[0], '<ul id="nav"><li>one</li><li>two</li><li>three</li></ul>')
 
 
     def test_stanPrecompiled(self):
@@ -55,7 +55,7 @@ class TestDocFactories(unittest.TestCase):
         df = loaders.stan(doc)
         loaded = df.load()
         self.assertEqual(loaded[0], '<ul id="nav"><li>one</li><li>two</li>')
-        self.failUnless(isinstance(loaded[1], _PrecompiledSlot))
+        self.assertTrue(isinstance(loaded[1], _PrecompiledSlot))
         self.assertEqual(loaded[1].name, 'three')
         self.assertEqual(loaded[2], '</ul>')
 
@@ -63,7 +63,7 @@ class TestDocFactories(unittest.TestCase):
     def test_htmlstr(self):
         doc = '<ul id="nav"><li>a</li><li>b</li><li>c</li></ul>'
         df = loaders.htmlstr(doc)
-        self.assertEquals(df.load()[0], doc)
+        self.assertEqual(df.load()[0], doc)
     test_htmlstr.suppress = [
         util.suppress(message=
                       r"\[v0.8\] htmlstr is deprecated because it's buggy. "
@@ -77,7 +77,7 @@ class TestDocFactories(unittest.TestCase):
         f.write(doc)
         f.close()
         df = loaders.htmlfile(temp)
-        self.assertEquals(df.load()[0], doc)
+        self.assertEqual(df.load()[0], doc)
     test_htmlfile.suppress = [
         util.suppress(message=
                       r"\[v0.8\] htmlfile is deprecated because it's buggy. "
@@ -91,7 +91,7 @@ class TestDocFactories(unittest.TestCase):
         f.write(doc)
         f.close()
         df = loaders.htmlfile(temp)
-        self.assertEquals(df.load()[0].children, ['Hi there'])
+        self.assertEqual(df.load()[0].children, ['Hi there'])
     test_htmlfile_slots.suppress = [
         util.suppress(message=
                       r"\[v0.8\] htmlfile is deprecated because it's buggy. "
@@ -101,7 +101,7 @@ class TestDocFactories(unittest.TestCase):
     def test_xmlstr(self):
         doc = '<ul id="nav"><li>a</li><li>b</li><li>c</li></ul>'
         df = loaders.xmlstr(doc)
-        self.assertEquals(df.load()[0], doc)
+        self.assertEqual(df.load()[0], doc)
 
 
     def test_xmlstrPreprocessors(self):
@@ -121,7 +121,7 @@ class TestDocFactories(unittest.TestCase):
         f.write(doc)
         f.close()
         df = loaders.xmlfile(temp)
-        self.assertEquals(df.load()[0], doc)
+        self.assertEqual(df.load()[0], doc)
 
 
     def test_xmlfilePreprocessors(self):
@@ -142,19 +142,19 @@ class TestDocFactories(unittest.TestCase):
         """
         doc = t.div[t.p[t.span(pattern='inner')['something']]]
         df = loaders.stan(doc, pattern='inner')
-        self.assertEquals(df.load()[0].tagName, 'span')
-        self.assertEquals(df.load()[0].children[0], 'something')
+        self.assertEqual(df.load()[0].tagName, 'span')
+        self.assertEqual(df.load()[0].children[0], 'something')
 
 
     def test_ignoreDocType(self):
         doc = '''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n<html><body><p>Hello.</p></body></html>'''
         df = loaders.xmlstr(doc, ignoreDocType=True)
-        self.assertEquals(flat.flatten(df), '<html><body><p>Hello.</p></body></html>')
+        self.assertEqual(flat.flatten(df), '<html><body><p>Hello.</p></body></html>')
 
     def test_ignoreComment(self):
         doc = '<!-- skip this --><p>Hello.</p>'
         df = loaders.xmlstr(doc, ignoreComment=True)
-        self.assertEquals(flat.flatten(df), '<p>Hello.</p>')
+        self.assertEqual(flat.flatten(df), '<p>Hello.</p>')
 
 
 class TestDocFactoriesCache(unittest.TestCase):
@@ -178,10 +178,10 @@ class TestDocFactoriesCache(unittest.TestCase):
     def test_stan(self):
 
         loader = loaders.stan(self.stan)
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         loader = loaders.stan(self.stan, pattern='1')
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         l1 = loaders.stan(self.stan, pattern='1')
         l2 = loaders.stan(self.stan, pattern='1')
@@ -194,10 +194,10 @@ class TestDocFactoriesCache(unittest.TestCase):
 
     def test_htmlstr(self):
         loader = loaders.htmlstr(self.doc)
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         loader = loaders.htmlstr(self.doc, pattern='1')
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         l1 = loaders.htmlstr(self.doc, pattern='1')
         l2 = loaders.htmlstr(self.doc, pattern='1')
@@ -219,7 +219,7 @@ class TestDocFactoriesCache(unittest.TestCase):
         f.close()
 
         loader = loaders.htmlfile(temp)
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         l1 = loaders.htmlfile(temp, pattern='1')
         l2 = loaders.htmlfile(temp, pattern='1')
@@ -242,7 +242,7 @@ class TestDocFactoriesCache(unittest.TestCase):
 
         loader = loaders.htmlfile(temp)
         r = loader.load()
-        self.assertEquals(id(r), id(loader.load()))
+        self.assertEqual(id(r), id(loader.load()))
         os.utime(temp, (os.path.getatime(temp), os.path.getmtime(temp)+5))
         self.assertNotEqual(id(r), id(loader.load()))
     test_htmlfileReload.suppress = [
@@ -255,10 +255,10 @@ class TestDocFactoriesCache(unittest.TestCase):
     def test_xmlstr(self):
 
         loader = loaders.xmlstr(self.nsdoc)
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         loader = loaders.xmlstr(self.nsdoc, pattern='1')
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         l1 = loaders.xmlstr(self.nsdoc, pattern='1')
         l2 = loaders.xmlstr(self.nsdoc, pattern='1')
@@ -283,8 +283,8 @@ class TestDocFactoriesCache(unittest.TestCase):
         '''
         loader = loaders.xmlstr(slotsdoc)
         loaded = loader.load()
-        self.assertEquals(loaded[1].default, None)
-        self.assertEquals(loaded[3].default, "3")
+        self.assertEqual(loaded[1].default, None)
+        self.assertEqual(loaded[3].default, "3")
 
 
     def test_xmlfile(self):
@@ -295,10 +295,10 @@ class TestDocFactoriesCache(unittest.TestCase):
         f.close()
 
         loader = loaders.xmlfile(temp)
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         loader = loaders.xmlfile(temp, pattern='1')
-        self.assertEquals( id(loader.load()), id(loader.load()) )
+        self.assertEqual( id(loader.load()), id(loader.load()) )
 
         l1 = loaders.xmlfile(temp, pattern='1')
         l2 = loaders.xmlfile(temp, pattern='1')
@@ -317,7 +317,7 @@ class TestDocFactoriesCache(unittest.TestCase):
 
         loader = loaders.xmlfile(temp)
         r = loader.load()
-        self.assertEquals(id(r), id(loader.load()))
+        self.assertEqual(id(r), id(loader.load()))
         os.utime(temp, (os.path.getatime(temp), os.path.getmtime(temp)+5))
         self.assertNotEqual(id(r), id(loader.load()))
 
@@ -351,7 +351,7 @@ class TestDocFactoriesCache(unittest.TestCase):
 
         self.assertIn('foo', before)
         self.assertIn('bar', after)
-        self.failIfEqual(before, after)
+        self.assertNotEqual(before, after)
     test_reloadAfterPrecompile.todo = \
         'Fix so that disk templates are reloaded even after a precompile. ' \
         'Probably just a matter of making the DocSerializer really lazy'
@@ -398,8 +398,8 @@ class TestContext(unittest.TestCase):
 
     def _withAndWithout(self, loader):
         ctx = context.WovenContext()
-        self.assertEquals(loader.load(), ['<p>hello</p>'])
-        self.assertEquals(loader.load(ctx), ['<p>hello</p>'])
+        self.assertEqual(loader.load(), ['<p>hello</p>'])
+        self.assertEqual(loader.load(ctx), ['<p>hello</p>'])
 
 
 class TestParsing(unittest.TestCase):
@@ -411,4 +411,4 @@ class TestParsing(unittest.TestCase):
         ## hard to fix. If you need this, switch to xmlstr.
         result = loaders.xmlstr(doc).load()
         # There should be a space between the two slots
-        self.assertEquals(result[2], ' ')
+        self.assertEqual(result[2], ' ')

--- a/nevow/test/test_newflat.py
+++ b/nevow/test/test_newflat.py
@@ -33,7 +33,7 @@ from nevow.context import WovenContext
 # lambda to avoid adding anything else to this namespace.  The result will
 # be a string which agrees with the one the traceback module will put into a
 # traceback for frames associated with functions defined in this file.
-HERE = (lambda: None).func_code.co_filename
+HERE = (lambda: None).__code__.co_filename
 
 
 class TrivialRenderable(object):
@@ -193,8 +193,8 @@ class FlattenTests(TestCase, FlattenMixin):
         An instance of L{unicode} is flattened to the UTF-8 representation of
         itself.
         """
-        self.assertStringEqual(self.flatten(u'bytes<>&"\0'), 'bytes<>&"\0')
-        unich = u"\N{LATIN CAPITAL LETTER E WITH GRAVE}"
+        self.assertStringEqual(self.flatten('bytes<>&"\0'), 'bytes<>&"\0')
+        unich = "\N{LATIN CAPITAL LETTER E WITH GRAVE}"
         self.assertStringEqual(self.flatten(unich), unich.encode('utf-8'))
 
 
@@ -203,7 +203,7 @@ class FlattenTests(TestCase, FlattenMixin):
         An L{xml} instance is flattened to the UTF-8 representation of itself.
         """
         self.assertStringEqual(self.flatten(xml("foo")), "foo")
-        unich = u"\N{LATIN CAPITAL LETTER E WITH GRAVE}"
+        unich = "\N{LATIN CAPITAL LETTER E WITH GRAVE}"
         self.assertStringEqual(self.flatten(xml(unich)), unich.encode('utf-8'))
 
 
@@ -303,8 +303,8 @@ class FlattenTests(TestCase, FlattenMixin):
         A L{Tag} with a C{tagName} attribute which is C{unicode} instead of
         C{str} is flattened to an XML representation.
         """
-        self.assertStringEqual(self.flatten(Tag(u'div')), "<div></div>")
-        self.assertStringEqual(self.flatten(Tag(u'div')['']), "<div></div>")
+        self.assertStringEqual(self.flatten(Tag('div')), "<div></div>")
+        self.assertStringEqual(self.flatten(Tag('div')['']), "<div></div>")
 
 
     def test_unicodeAttributeName(self):
@@ -313,7 +313,7 @@ class FlattenTests(TestCase, FlattenMixin):
         is flattened to an XML representation.
         """
         self.assertStringEqual(
-            self.flatten(Tag(u'div', {u'foo': 'bar'})), '<div foo="bar"></div>')
+            self.flatten(Tag('div', {'foo': 'bar'})), '<div foo="bar"></div>')
 
 
     def test_stringTagAttributes(self):
@@ -820,7 +820,7 @@ class FlattenTests(TestCase, FlattenMixin):
         significantly greater than the Python maximum recursion limit.
         """
         obj = ["foo"]
-        for i in xrange(1000):
+        for i in range(1000):
             obj = [obj]
         self._nestingTest(obj, "foo")
 
@@ -831,7 +831,7 @@ class FlattenTests(TestCase, FlattenMixin):
         significantly greater than the Python maximum recursion limit.
         """
         tag = div()[slot("foo-0")]
-        for i in xrange(1000):
+        for i in range(1000):
             tag.fillSlots("foo-" + str(i), slot("foo-" + str(i + 1)))
         tag.fillSlots("foo-1000", "bar")
         self._nestingTest(tag, "<div>bar</div>")
@@ -844,7 +844,7 @@ class FlattenTests(TestCase, FlattenMixin):
         """
         n = 1000
         tag = div["foo"]
-        for i in xrange(n - 1):
+        for i in range(n - 1):
             tag = div[tag]
         self._nestingTest(tag, "<div>" * n + "foo" + "</div>" * n)
 
@@ -855,7 +855,7 @@ class FlattenTests(TestCase, FlattenMixin):
         nesting significantly greater than the Python maximum recursion limit.
         """
         obj = TrivialRenderable("foo")
-        for i in xrange(1000):
+        for i in range(1000):
             obj = TrivialRenderable(obj)
         self._nestingTest(obj, "foo")
 
@@ -971,13 +971,13 @@ class FlattenerErrorTests(TestCase):
         """
         self.assertEqual(
             str(FlattenerError(
-                    RuntimeError("reason"), [u'abc\N{SNOWMAN}xyz'], [])),
+                    RuntimeError("reason"), ['abc\N{SNOWMAN}xyz'], [])),
             "Exception while flattening:\n"
             "  u'abc\\u2603xyz'\n" # Codepoint for SNOWMAN
             "RuntimeError: reason\n")
         self.assertEqual(
             str(FlattenerError(
-                    RuntimeError("reason"), [u'01234567\N{SNOWMAN}9' * 10],
+                    RuntimeError("reason"), ['01234567\N{SNOWMAN}9' * 10],
                     [])),
             "Exception while flattening:\n"
             "  u'01234567\\u2603901234567\\u26039<...>01234567\\u2603901234567"
@@ -1048,7 +1048,7 @@ class FlattenerErrorTests(TestCase):
 
         try:
             f()
-        except RuntimeError, exc:
+        except RuntimeError as exc:
             # Get the traceback, minus the info for *this* frame
             tbinfo = traceback.extract_tb(sys.exc_info()[2])[1:]
         else:
@@ -1062,8 +1062,8 @@ class FlattenerErrorTests(TestCase):
             "  File \"%s\", line %d, in g\n"
             "    raise RuntimeError(\"reason\")\n"
             "RuntimeError: reason\n" % (
-                HERE, f.func_code.co_firstlineno + 1,
-                HERE, g.func_code.co_firstlineno + 1))
+                HERE, f.__code__.co_firstlineno + 1,
+                HERE, g.__code__.co_firstlineno + 1))
 
 
 
@@ -1234,8 +1234,8 @@ class DeferflattenTests(TestCase, FlattenMixin):
         frames allowed by the Python recursion limit succeeds if all the
         L{Deferred}s have results already.
         """
-        results = [str(i) for i in xrange(1000)]
-        deferreds = map(succeed, results)
+        results = [str(i) for i in range(1000)]
+        deferreds = list(map(succeed, results))
         limit = sys.getrecursionlimit()
         sys.setrecursionlimit(100)
         try:

--- a/nevow/test/test_newflat.py
+++ b/nevow/test/test_newflat.py
@@ -7,7 +7,7 @@ Tests for L{nevow._flat}.
 
 import sys, traceback
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import Deferred, succeed
@@ -35,7 +35,7 @@ from nevow.context import WovenContext
 # traceback for frames associated with functions defined in this file.
 HERE = (lambda: None).__code__.co_filename
 
-
+@implementer(IRenderable)
 class TrivialRenderable(object):
     """
     An object which renders to a parameterized value.
@@ -43,7 +43,6 @@ class TrivialRenderable(object):
     @ivar result: The object which will be returned by the render method.
     @ivar requests: A list of all the objects passed to the render method.
     """
-    implements(IRenderable)
 
     def __init__(self, result):
         self.result = result
@@ -58,7 +57,7 @@ class TrivialRenderable(object):
         return self.result
 
 
-
+@implementer(IRenderable)
 class RenderRenderable(object):
     """
     An object which renders to a parameterized value and has a render method
@@ -70,7 +69,6 @@ class RenderRenderable(object):
     @ivar tag: The value which will be returned from C{render}.
     @ivar result: The value which will be returned from the render method.
     """
-    implements(IRenderable)
 
     def __init__(self, renders, name, tag, result):
         self.renders = renders
@@ -529,8 +527,8 @@ class FlattenTests(TestCase, FlattenMixin):
         replaced with the return value of the named renderer on the
         L{IRenderable} which had the render method which returned the L{Tag}.
         """
+        @implementer(IRenderable)
         class TwoRenderers(object):
-            implements(IRenderable)
 
             def renderer(self, name):
                 return getattr(self, name)
@@ -573,8 +571,8 @@ class FlattenTests(TestCase, FlattenMixin):
         If a render method returns the tag it was passed, the tag is flattened
         as though it did not have a render directive.
         """
+        @implementer(IRenderable)
         class IdempotentRenderable(object):
-            implements(IRenderable)
 
             def renderer(self, name):
                 return getattr(self, name)
@@ -919,8 +917,8 @@ class FlattenTests(TestCase, FlattenMixin):
         def broken():
             raise RuntimeError("foo")
 
+        @implementer(IRenderable)
         class BrokenRenderable(object):
-            implements(IRenderable)
 
             def render(self, request):
                 # insert another stack frame before the exception
@@ -991,8 +989,8 @@ class FlattenerErrorTests(TestCase):
         the repr of that object is included in the string representation of the
         exception.
         """
+        @implementer(IRenderable)
         class Renderable(object):
-            implements(IRenderable)
 
             def __repr__(self):
                 return "renderable repr"
@@ -1150,8 +1148,8 @@ class DeferflattenTests(TestCase, FlattenMixin):
         """
         class TestException(Exception):
             pass
+        @implementer(IRenderable)
         class BrokenRenderable(object):
-            implements(IRenderable)
 
             def render(self, request):
                 raise TestException()

--- a/nevow/test/test_nit.py
+++ b/nevow/test/test_nit.py
@@ -15,7 +15,7 @@ from nevow.livetrial.testcase import TestSuite, TestError
 from nevow.livetrial.runner import TestFrameworkRoot
 from nevow.scripts import nit
 
-MESSAGE = u'I am an error'
+MESSAGE = 'I am an error'
 
 
 

--- a/nevow/test/test_passobj.py
+++ b/nevow/test/test_passobj.py
@@ -65,7 +65,7 @@ class ObjectTester:
         ]
 
     def someMethod(self, one, two):
-        print "ONE TWO", `one`, `two`
+        print("ONE TWO", repr(one), repr(two))
 
     def frobber(self, frobber, frobee):
         return frobber.frobazz(frobee)
@@ -193,7 +193,7 @@ class AnotherTest:
                 return "Breakpoint in file %s at line %s" % (self.fn, self.ln)
 
         breakpoints = BreakpointRemover()
-        for fn in debugInstance.breaks.keys():
+        for fn in list(debugInstance.breaks.keys()):
             for lineno in debugInstance.breaks[fn]:
                 breakpoints.append(BP(fn, lineno))
         return breakpoints

--- a/nevow/test/test_passobj.py
+++ b/nevow/test/test_passobj.py
@@ -2,14 +2,13 @@
 # See LICENSE for details.
 
 import formless
-from zope.interface import implements
+from zope.interface import implementer
 
 class IBar(formless.TypedInterface):
     bar = formless.String()
 
-
+@implementer(IBar)
 class Bar:
-    implements(IBar)
 
     def __init__(self, bar):
         self.bar = bar
@@ -21,9 +20,8 @@ class Bar:
 class IFrob(formless.TypedInterface):
     integer = formless.Integer()
 
-
+@implementer(IFrob)
 class Frob:
-    implements(IFrob)
 
     def __init__(self, integer):
         self.integer = integer
@@ -54,9 +52,8 @@ class IObjectTest(formless.TypedInterface):
 
     someList = formless.List()
 
-
+@implementer(IObjectTest)
 class ObjectTester:
-    implements(IObjectTest)
 
     def __init__(self):
         self.someList = [
@@ -144,9 +141,8 @@ class IAnotherTest(formless.TypedInterface):
         return formless.Object(label="The Answer", interface=formless.Integer)
     compoundChecker = formless.autocallable(compoundChecker)
 
-
+@implementer(IAnotherTest)
 class AnotherTest:
-    implements(IAnotherTest)
 
     def aBarMethod(self, abar):
         return "You passed me %s" % abar
@@ -184,8 +180,8 @@ class AnotherTest:
                     del debugInstance.breaks[removal.fn]
                 list.remove(self, removal)
         class Dummy(formless.TypedInterface): pass
+        @implementer(Dummy)
         class BP:
-            implements(Dummy)
             def __init__(self, fn, ln):
                 self.fn=fn
                 self.ln=ln

--- a/nevow/test/test_query.py
+++ b/nevow/test/test_query.py
@@ -172,7 +172,7 @@ class OnePatternTestCase(testutil.TestCase):
         T.pattern = "outer"
         C = context.WovenContext(tag=T)
         new = IQ(C).onePattern('outer')
-        self.assertEquals(new.tagName, 'html')
+        self.assertEqual(new.tagName, 'html')
 
     def test_listNotEnough(self):
         P = flat.precompile(notEnough)
@@ -189,11 +189,11 @@ multiple = tags.html[tags.div(pattern="foo", bar="one"), tags.span(pattern="foo"
 class TestAll(testutil.TestCase):
     def verify(self, them):
         them = list(them)
-        self.assertEquals(len(them), 2)
-        self.assertEquals(them[0].tagName, 'div')
-        self.assertEquals(them[1].tagName, 'span')
-        self.assertEquals(them[0].attributes['bar'], 'one')
-        self.assertEquals(them[1].attributes['bar'], 'two')
+        self.assertEqual(len(them), 2)
+        self.assertEqual(them[0].tagName, 'div')
+        self.assertEqual(them[1].tagName, 'span')
+        self.assertEqual(them[0].attributes['bar'], 'one')
+        self.assertEqual(them[1].attributes['bar'], 'two')
 
     def testTagPatterns(self):
         self.verify(
@@ -218,14 +218,14 @@ class TestGenerator(testutil.TestCase):
         two = it(color="blue")
         three = it(color="green")
         four = it(color="orange")
-        self.assertEquals(one.attributes['color'], 'red')
-        self.assertEquals(one.attributes['bar'], 'one')
-        self.assertEquals(two.attributes['color'], 'blue')
-        self.assertEquals(two.attributes['bar'], 'two')
-        self.assertEquals(three.attributes['color'], 'green')
-        self.assertEquals(three.attributes['bar'], 'one')
-        self.assertEquals(four.attributes['color'], 'orange')
-        self.assertEquals(four.attributes['bar'], 'two')
+        self.assertEqual(one.attributes['color'], 'red')
+        self.assertEqual(one.attributes['bar'], 'one')
+        self.assertEqual(two.attributes['color'], 'blue')
+        self.assertEqual(two.attributes['bar'], 'two')
+        self.assertEqual(three.attributes['color'], 'green')
+        self.assertEqual(three.attributes['bar'], 'one')
+        self.assertEqual(four.attributes['color'], 'orange')
+        self.assertEqual(four.attributes['bar'], 'two')
 
     def testTagGenerators(self):
         self.verify(
@@ -258,14 +258,14 @@ class TestGenerator(testutil.TestCase):
     def testClonableDefault(self):
         orig = tags.p["Hello"]
         gen = IQ(flat.precompile(notEnough)).patternGenerator('foo', orig)
-        new = gen.next()
-        self.assertEquals(new.tagName, 'p')
+        new = next(gen)
+        self.assertEqual(new.tagName, 'p')
         self.assertNotIdentical(orig, new)
 
     def testNonClonableDefault(self):
         gen = IQ(flat.precompile(notEnough)).patternGenerator('foo', 'bar')
-        new = gen.next()
-        self.assertEquals(new, 'bar')
+        new = next(gen)
+        self.assertEqual(new, 'bar')
 
     def testXmlMissing(self):
         self.assertRaises(stan.NodeNotFound, IQ(stan.xml('<html>hello</html>')).patternGenerator, 'foo')
@@ -277,5 +277,5 @@ class TestGenerator(testutil.TestCase):
         the tag has a matching pattern special.
         """
         patterns = IQ([tags.div(pattern="foo", bar="baz")]).patternGenerator("foo")
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(patterns.next().attributes['bar'], "baz")

--- a/nevow/test/test_rend.py
+++ b/nevow/test/test_rend.py
@@ -52,7 +52,7 @@ class TestPage(unittest.TestCase):
         xhtml = '<ul id="nav"><li>one</li><li>two</li><li>three</li></ul>'
         r = rend.Page(docFactory=loaders.htmlstr(xhtml))
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, xhtml))
+            lambda result: self.assertEqual(result, xhtml))
     test_simple.suppress = [
         SUPPRESS(message=
                  r"\[v0.8\] htmlstr is deprecated because it's buggy. "
@@ -66,7 +66,7 @@ class TestPage(unittest.TestCase):
             docFactory = loaders.htmlstr(xhtml)
         r = R()
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, xhtml))
+            lambda result: self.assertEqual(result, xhtml))
     test_extend.suppress = [
         SUPPRESS(message=
                  r"\[v0.8\] htmlstr is deprecated because it's buggy. "
@@ -85,7 +85,7 @@ class TestPage(unittest.TestCase):
                 return ['one', 'two', 'three']
         r = R()
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(
+            lambda result: self.assertEqual(
             result,
             '<ul id="nav"><li>one</li><li>two</li><li>three</li></ul>'))
     test_data.suppress = [
@@ -120,7 +120,7 @@ class TestPage(unittest.TestCase):
 
         r = R()
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, '<span>abc</span>'))
+            lambda result: self.assertEqual(result, '<span>abc</span>'))
     test_render.suppress = [
         SUPPRESS(message=
                  r"\[v0.8\] htmlstr is deprecated because it's buggy. "
@@ -151,7 +151,7 @@ class TestPage(unittest.TestCase):
         r = R()
         d = deferredRender(r)
         d.addCallback(
-            lambda result: self.assertEquals(
+            lambda result: self.assertEqual(
                 result,
                 '<table>'
                 '<tr><th>English</th><th>French</th></tr>'
@@ -176,7 +176,7 @@ class TestPage(unittest.TestCase):
 
         r = R()
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, '<ul><li>one</li><li>two</li><li>three</li></ul>'))
+            lambda result: self.assertEqual(result, '<ul><li>one</li><li>two</li><li>three</li></ul>'))
 
     def test_stanRender(self):
 
@@ -189,7 +189,7 @@ class TestPage(unittest.TestCase):
 
         r = R()
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, '<span>abc</span>'))
+            lambda result: self.assertEqual(result, '<span>abc</span>'))
 
     def test_stanDataAndRender(self):
 
@@ -216,7 +216,7 @@ class TestPage(unittest.TestCase):
 
         r = R()
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, '<table><tr><th>English</th><th>French</th></tr><tr><td>one</td><td>un/une</td></tr><tr><td>two</td><td>deux</td></tr><tr><td>three</td><td>trois</td></tr></table>'))
+            lambda result: self.assertEqual(result, '<table><tr><th>English</th><th>French</th></tr><tr><td>one</td><td>un/une</td></tr><tr><td>two</td><td>deux</td></tr><tr><td>three</td><td>trois</td></tr></table>'))
 
     def test_composite(self):
 
@@ -232,7 +232,7 @@ class TestPage(unittest.TestCase):
                 )
         r = R()
         return deferredRender(r).addCallback(
-            lambda result: self.assertEquals(result, '<div id="outer"><div id="inner"></div></div>'))
+            lambda result: self.assertEqual(result, '<div id="outer"><div id="inner"></div></div>'))
 
     def _testDocFactoryInStanTree(self, docFactory, expected):
         class Page(rend.Page):
@@ -353,7 +353,7 @@ class TestPage(unittest.TestCase):
         p = Page()
         return deferredRender(p).addCallback(
             lambda result:
-            self.assertEquals(result, '<html><head><title>test</title></head></html>'))
+            self.assertEqual(result, '<html><head><title>test</title></head></html>'))
 
     def test_component(self):
         """
@@ -381,7 +381,7 @@ class TestPage(unittest.TestCase):
         page = Page()
         return deferredRender(page).addCallback(
             lambda result:
-            self.assertEquals(result, '<div><p><strong>foo</strong> bar</p></div>'))
+            self.assertEqual(result, '<div><p><strong>foo</strong> bar</p></div>'))
 
     def test_fragmentContext(self):
         # A fragment is remembered as the IRendererFactory. It must create a new context
@@ -415,8 +415,8 @@ class TestPage(unittest.TestCase):
 
         result = Page().renderSynchronously()
         # print result
-        self.failIf("'foo' was not found" in result)
-        self.failIf("'after' was not found" in result)
+        self.assertFalse("'foo' was not found" in result)
+        self.assertFalse("'after' was not found" in result)
 
 
     def test_rendererNotFound(self):
@@ -434,7 +434,7 @@ class TestPage(unittest.TestCase):
             docFactory = loaders.stan(html(render=directive("notfound")))
         page = Page()
         result = page.renderSynchronously()
-        self.assertEquals(
+        self.assertEqual(
             result,
             "<html>The renderer named 'notfound' was not found in %s.</html>"
             % util.escapeToXML(repr(page)))
@@ -453,7 +453,7 @@ class TestPage(unittest.TestCase):
             docFactory = loaders.stan(html(render=directive("notfound dummy")))
         page = Page()
         result = page.renderSynchronously()
-        self.assertEquals(
+        self.assertEqual(
             result,
             "<html>The renderer named 'notfound' was not found in %s.</html>"
             % util.escapeToXML(repr(page)))
@@ -502,7 +502,7 @@ class TestRenderFactory(unittest.TestCase):
     def test_dataRenderer(self):
         ctx = context.WovenContext()
         ctx.remember(rend.RenderFactory(), inevow.IRendererFactory)
-        self.assertEquals(flat.flatten(p(data='foo', render=directive('data')), ctx), '<p>foo</p>')
+        self.assertEqual(flat.flatten(p(data='foo', render=directive('data')), ctx), '<p>foo</p>')
 
 class TestConfigurableMixin(unittest.TestCase):
     def test_formRender(self):
@@ -554,7 +554,7 @@ class TestConfigurableMixin(unittest.TestCase):
 
         ctx = context.WovenContext()
         result = FormPage().postForm(ctx, 'test1', {'foo': ['42']})
-        return result.addCallback(lambda result: self.assertEquals(result, 42))
+        return result.addCallback(lambda result: self.assertEqual(result, 42))
 
     def test_formPostDeferred(self):
         class FormPage(rend.Page):
@@ -564,7 +564,7 @@ class TestConfigurableMixin(unittest.TestCase):
 
         ctx = context.WovenContext()
         result = FormPage().postForm(ctx, 'test1', {'foo': ['42']})
-        return result.addCallback(lambda result: self.assertEquals(result, 42))
+        return result.addCallback(lambda result: self.assertEqual(result, 42))
 
     def test_formPostFailure(self):
         class FormPage(rend.Page):
@@ -649,7 +649,7 @@ class TestRenderString(unittest.TestCase):
     def test_simple(self):
         doc = div[p['foo'],p['bar']]
         return rend.Page(docFactory=loaders.stan(doc)).renderString().addCallback(
-            lambda result: self.assertEquals(result, '<div><p>foo</p><p>bar</p></div>'))
+            lambda result: self.assertEqual(result, '<div><p>foo</p><p>bar</p></div>'))
 
     def test_parentCtx(self):
         class IFoo(Interface):
@@ -662,7 +662,7 @@ class TestRenderString(unittest.TestCase):
             docFactory = loaders.stan(p[render_foo])
         return Page().renderString(ctx).addCallback(
             lambda result:
-            self.assertEquals(
+            self.assertEqual(
             result,
             '<p>Hello!</p>'
             ))
@@ -683,7 +683,7 @@ class TestRenderString(unittest.TestCase):
                 return ctx.tag.clear()[data+'bar']
 
         return Page().renderString().addCallback(
-            lambda result: self.assertEquals(result, '<html><body><p>foobar</p></body></html>'))
+            lambda result: self.assertEqual(result, '<html><body><p>foobar</p></body></html>'))
 
 
 class TestRenderSynchronously(unittest.TestCase):
@@ -692,7 +692,7 @@ class TestRenderSynchronously(unittest.TestCase):
 
         doc = div[p['foo'],p['bar']]
         result = rend.Page(docFactory=loaders.stan(doc)).renderSynchronously()
-        self.assertEquals(result, '<div><p>foo</p><p>bar</p></div>')
+        self.assertEqual(result, '<div><p>foo</p><p>bar</p></div>')
 
     def test_parentCtx(self):
         class IFoo(Interface):
@@ -703,7 +703,7 @@ class TestRenderSynchronously(unittest.TestCase):
             def render_foo(self, ctx, data):
                 return IFoo(ctx)
             docFactory = loaders.stan(p[render_foo])
-        self.assertEquals(Page().renderSynchronously(ctx), '<p>Hello!</p>')
+        self.assertEqual(Page().renderSynchronously(ctx), '<p>Hello!</p>')
 
 
 def getResource(root, path):
@@ -722,7 +722,7 @@ class TestLocateChild(unittest.TestCase):
         p = Parent()
         p.putChild('child', Child())
         return getResource(p, '/child').addCallback(
-            lambda r: self.failUnless(inevow.IResource.providedBy(r.tag)))
+            lambda r: self.assertTrue(inevow.IResource.providedBy(r.tag)))
 
     def test_resourceAttr(self):
         class Child(rend.Page):
@@ -731,7 +731,7 @@ class TestLocateChild(unittest.TestCase):
             child_child = Child()
         p = Parent()
         return getResource(p, '/child').addCallback(
-            lambda r: self.failUnless(inevow.IResource.providedBy(r.tag)))
+            lambda r: self.assertTrue(inevow.IResource.providedBy(r.tag)))
 
     def test_methodAttr(self):
         class Child(rend.Page):
@@ -748,11 +748,11 @@ class TestLocateChild(unittest.TestCase):
 
         return defer.DeferredList([
             getResource(p, '/now').addCallback(
-            lambda r: self.failUnless(inevow.IResource.providedBy(r.tag))),
+            lambda r: self.assertTrue(inevow.IResource.providedBy(r.tag))),
 
             getResource(p, '/defer').addCallback(
 
-            lambda r: self.failUnless(inevow.IResource.providedBy(r.tag)))],
+            lambda r: self.assertTrue(inevow.IResource.providedBy(r.tag)))],
                                   fireOnOneErrback=True)
 
     def test_childFactory(self):
@@ -773,7 +773,7 @@ class TestLocateChild(unittest.TestCase):
             child_child = twcgi.CGIScript('abc.cgi')
         p = Parent()
         return getResource(p, '/child').addCallback(
-            lambda r: self.failUnless(inevow.IResource.providedBy(r.tag)))
+            lambda r: self.assertTrue(inevow.IResource.providedBy(r.tag)))
 
     def test_noneChild(self):
         class Parent(rend.Page):
@@ -785,10 +785,10 @@ class TestLocateChild(unittest.TestCase):
 
         return defer.DeferredList([
             getResource(p, '/child').addCallback(
-            lambda r: self.failUnless(isinstance(r.tag, rend.FourOhFour))),
+            lambda r: self.assertTrue(isinstance(r.tag, rend.FourOhFour))),
 
             getResource(p, '/other').addCallback(
-            lambda r: self.failUnless(isinstance(r.tag, rend.FourOhFour))
+            lambda r: self.assertTrue(isinstance(r.tag, rend.FourOhFour))
             )],
                                   fireOnOneErrback=True)
 
@@ -810,7 +810,7 @@ class TestLocateChild(unittest.TestCase):
 
         page = Page()
         return getResource(page, '/child').addCallback(
-            lambda r: self.failUnless(inevow.IResource.providedBy(r.tag)))
+            lambda r: self.assertTrue(inevow.IResource.providedBy(r.tag)))
 
     def test_redirectToURL(self):
         redirectTarget = "http://example.com/bar"
@@ -823,7 +823,7 @@ class TestLocateChild(unittest.TestCase):
             ## Render the redirect.
             r.tag.renderHTTP(r)
             req = inevow.IRequest(r)
-            self.assertEquals(req.redirected_to, redirectTarget)
+            self.assertEqual(req.redirected_to, redirectTarget)
 
         return getResource(page, '/url').addCallback(doAssert)
 
@@ -836,7 +836,7 @@ class TestLocateChild(unittest.TestCase):
 
         def dotest(r):
             r.tag.renderHTTP(r)
-            self.assertEquals(uchr,
+            self.assertEqual(uchr,
                               inevow.IRequest(r).redirected_to)
 
         return getResource(page, '/url').addCallback(dotest)
@@ -855,7 +855,7 @@ class TestLocateChild(unittest.TestCase):
 
         return getResource(page, '/foo').addCallback(
             lambda c: deferredRender(c.tag).addCallback(
-            lambda result: self.assertEquals(result, theString)))
+            lambda result: self.assertEqual(result, theString)))
 
     def test_freeformChildMixin_nonTrue(self):
         """Configurables that have c.__nonzero__()==False are accepted."""
@@ -872,15 +872,15 @@ class TestLocateChild(unittest.TestCase):
 
         D = getResource(page, '/foo')
         def x1(r):
-            self.failUnless(isinstance(r.tag, rend.FourOhFour))
+            self.assertTrue(isinstance(r.tag, rend.FourOhFour))
         D.addCallback(x1)
 
         def x2(ign):
             D2 = getResource(page, '/freeform_post!!foo')
             def x3(r):
-                self.failIf(isinstance(r.tag, rend.FourOhFour))
+                self.assertFalse(isinstance(r.tag, rend.FourOhFour))
                 return deferredRender(r.tag).addCallback(
-                    lambda result: self.assertEquals(result, 'You posted a form to foo'))
+                    lambda result: self.assertEqual(result, 'You posted a form to foo'))
             D2.addCallback(x3)
             return D2
         D.addCallback(x2)
@@ -890,10 +890,10 @@ class TestLocateChild(unittest.TestCase):
 
             D3 = getResource(page, '/freeform_post!!foo')
             def x5(r):
-                self.failIf(isinstance(r.tag, rend.FourOhFour))
+                self.assertFalse(isinstance(r.tag, rend.FourOhFour))
                 return deferredRender(r.tag).addCallback(
                     lambda result:
-                    self.assertEquals(result, 'You posted a form to foo'))
+                    self.assertEqual(result, 'You posted a form to foo'))
             return D3.addCallback(x5)
         D.addCallback(x4)
         return D
@@ -906,19 +906,19 @@ class TestStandardRenderers(unittest.TestCase):
 
         ctx.remember('foo', inevow.IData)
         tag = p(render=rend.data)
-        self.assertEquals(flat.flatten(tag, ctx), '<p>foo</p>')
+        self.assertEqual(flat.flatten(tag, ctx), '<p>foo</p>')
 
         ctx.remember('\xc2\xa3'.decode('utf-8'), inevow.IData)
         tag = p(render=rend.data)
-        self.assertEquals(flat.flatten(tag, ctx), '<p>\xc2\xa3</p>')
+        self.assertEqual(flat.flatten(tag, ctx), '<p>\xc2\xa3</p>')
 
         ctx.remember([1,2,3,4,5], inevow.IData)
         tag = p(render=rend.data)
-        self.assertEquals(flat.flatten(tag, ctx), '<p>12345</p>')
+        self.assertEqual(flat.flatten(tag, ctx), '<p>12345</p>')
 
         ctx.remember({'foo':'bar'}, inevow.IData)
         tag = p(data=directive('foo'), render=rend.data)
-        self.assertEquals(flat.flatten(tag, ctx), '<p>bar</p>')
+        self.assertEqual(flat.flatten(tag, ctx), '<p>bar</p>')
 
 class TestMacro(unittest.TestCase):
 
@@ -960,7 +960,7 @@ class TestMacro(unittest.TestCase):
         p1_str = p1.renderSynchronously(ctx1)
         p2_str = p2.renderSynchronously(ctx2)
 
-        self.assertNotEquals(p1_str, p2_str)
+        self.assertNotEqual(p1_str, p2_str)
 
     def test_macroInsideSpecialScope(self):
         """http://divmod.org/trac/ticket/490
@@ -1000,5 +1000,5 @@ class TestMacro(unittest.TestCase):
         p1_str = p1.renderSynchronously(ctx1)
         p2_str = p2.renderSynchronously(ctx2)
 
-        self.assertEquals(p1_str, p2_str)
+        self.assertEqual(p1_str, p2_str)
 

--- a/nevow/test/test_rend.py
+++ b/nevow/test/test_rend.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -589,15 +589,16 @@ class TestConfigurableMixin(unittest.TestCase):
 class IThing(formless.TypedInterface):
     foo = formless.String()
 
+@implementer(IThing)
 class Thing:
-    implements(IThing)
+    pass
+
 
 class TestLocateConfigurable(unittest.TestCase):
 
     def test_onSelf(self):
-
+        @implementer(IThing)
         class Page(rend.Page):
-            implements(IThing)
             docFactory = loaders.stan(html[freeform.renderForms()])
 
         page = Page()
@@ -636,8 +637,8 @@ class TestDeferredDefaultValue(unittest.TestCase):
         from nevow import util
         deferred = util.Deferred()
         deferred.callback('the default value')
+        @implementer(IDeferredProperty)
         class Implementation(object):
-            implements(IDeferredProperty)
             d = deferred
 
         return deferredRender(rend.Page(Implementation(), docFactory=loaders.stan(html[freeform.renderForms('original')]))).addCallback(
@@ -859,8 +860,8 @@ class TestLocateChild(unittest.TestCase):
 
     def test_freeformChildMixin_nonTrue(self):
         """Configurables that have c.__nonzero__()==False are accepted."""
+        @implementer(iformless.IConfigurable)
         class SimpleConf(object):
-            implements(iformless.IConfigurable)
             # mock mock
             def postForm(self, ctx, bindingName, args):
                 return 'SimpleConf OK'

--- a/nevow/test/test_stan.py
+++ b/nevow/test/test_stan.py
@@ -9,19 +9,19 @@ class TestProto(TestCase):
     def test_proto(self):
         tagName = "hello"
         proto = stan.Proto(tagName)
-        self.assertEquals(tagName, str(proto))
+        self.assertEqual(tagName, str(proto))
 
     def test_callCreatesTag(self):
         proto = stan.Proto("hello")
         tag = proto(world="1")
-        self.assertEquals(proto, tag.tagName)
-        self.assertEquals(tag.attributes['world'], '1')
+        self.assertEqual(proto, tag.tagName)
+        self.assertEqual(tag.attributes['world'], '1')
 
     def test_getItemCreatesTag(self):
         proto = stan.Proto("hello")
         tag = proto[proto]
-        self.assertEquals(proto, tag.tagName)
-        self.assertEquals(tag.children, [proto])
+        self.assertEqual(proto, tag.tagName)
+        self.assertEqual(tag.children, [proto])
 
 
 proto = stan.Proto("hello")
@@ -35,11 +35,11 @@ class TestTag(TestCase):
         tag.lineNumber = 6
         tag.columnNumber = 12
         clone = tag.clone()
-        self.assertEquals(clone.attributes['hello'], 'world')
+        self.assertEqual(clone.attributes['hello'], 'world')
         self.assertNotIdentical(clone.attributes, tag.attributes)
-        self.assertEquals(clone.children, ["How are you"])
+        self.assertEqual(clone.children, ["How are you"])
         self.assertNotIdentical(clone.children, tag.children)
-        self.assertEquals(tag.slotData, clone.slotData)
+        self.assertEqual(tag.slotData, clone.slotData)
         self.assertNotIdentical(tag.slotData, clone.slotData)
         self.assertEqual(clone.filename, "foo/bar")
         self.assertEqual(clone.lineNumber, 6)
@@ -51,15 +51,15 @@ class TestTag(TestCase):
     def test_clear(self):
         tag = proto["these are", "children", "cool"]
         tag.clear()
-        self.assertEquals(tag.children, [])
+        self.assertEqual(tag.children, [])
 
     def test_specials(self):
         tag = proto(data=1, render=str, remember="stuff", key="myKey", **{'pattern': "item"})
-        self.assertEquals(tag.data, 1)
-        self.assertEquals(getattr(tag, 'render'), str)
-        self.assertEquals(tag.remember, "stuff")
-        self.assertEquals(tag.key, "myKey")
-        self.assertEquals(tag.pattern, "item")
+        self.assertEqual(tag.data, 1)
+        self.assertEqual(getattr(tag, 'render'), str)
+        self.assertEqual(tag.remember, "stuff")
+        self.assertEqual(tag.key, "myKey")
+        self.assertEqual(tag.pattern, "item")
 
 
     def test_visit(self):
@@ -79,7 +79,7 @@ class TestTag(TestCase):
         root[firstChild, secondChild]
         secondChild[firstGrandchild, secondGrandchild, thirdGrandchild]
         stan.visit(root, visitor)
-        self.assertEquals(
+        self.assertEqual(
             visited,
             [root, firstChild, secondChild,
              firstGrandchild, secondGrandchild, thirdGrandchild])
@@ -97,10 +97,10 @@ class TestUnderscore(TestCase):
         proto = stan.Proto('div')
         tag = proto()
         tag(_class='a')
-        self.assertEquals(tag.attributes, {'class': 'a'})
+        self.assertEqual(tag.attributes, {'class': 'a'})
 
     def test_suffix(self):
         proto = stan.Proto('div')
         tag = proto()
         tag(class_='a')
-        self.assertEquals(tag.attributes, {'class': 'a'})
+        self.assertEqual(tag.attributes, {'class': 'a'})

--- a/nevow/test/test_static.py
+++ b/nevow/test/test_static.py
@@ -30,108 +30,108 @@ class Range(unittest.TestCase):
     def testBodyLength(self):
         self.request.received_headers['range'] = 'bytes=0-1999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(len(r.v), 2000))
+            lambda r: self.assertEqual(len(r.v), 2000))
 
     def testBodyContent(self):
         self.request.received_headers['range'] = 'bytes=0-1999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.v, 200 * '0123456789'))
+            lambda r: self.assertEqual(r.v, 200 * '0123456789'))
 
     def testContentLength(self):
         """Content-Length of a request is correct."""
         self.request.received_headers['range'] = 'bytes=0-1999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '2000'))
+            lambda r: self.assertEqual(r.headers['content-length'], '2000'))
 
     def testContentRange(self):
         """Content-Range of a request is correct."""
         self.request.received_headers['range'] = 'bytes=0-1999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
+            lambda r: self.assertEqual(r.headers.get('content-range'),
                                         'bytes 0-1999/8000'))
 
     def testBodyLength_offset(self):
         self.request.received_headers['range'] = 'bytes=3-10'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(len(r.v), 8))
+            lambda r: self.assertEqual(len(r.v), 8))
 
     def testBodyContent_offset(self):
         self.request.received_headers['range'] = 'bytes=3-10'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.v, '34567890'))
+            lambda r: self.assertEqual(r.v, '34567890'))
 
     def testContentLength_offset(self):
         """Content-Length of a request is correct."""
         self.request.received_headers['range'] = 'bytes=3-10'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '8'))
+            lambda r: self.assertEqual(r.headers['content-length'], '8'))
 
     def testContentRange_offset(self):
         """Content-Range of a request is correct."""
         self.request.received_headers['range'] = 'bytes=3-10'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
+            lambda r: self.assertEqual(r.headers.get('content-range'),
                                         'bytes 3-10/8000'))
 
     def testBodyLength_end(self):
         self.request.received_headers['range'] = 'bytes=7991-7999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(len(r.v), 9))
+            lambda r: self.assertEqual(len(r.v), 9))
 
     def testBodyContent_end(self):
         self.request.received_headers['range'] = 'bytes=7991-7999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.v, '123456789'))
+            lambda r: self.assertEqual(r.v, '123456789'))
 
     def testContentLength_end(self):
         self.request.received_headers['range'] = 'bytes=7991-7999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '9'))
+            lambda r: self.assertEqual(r.headers['content-length'], '9'))
 
     def testContentRange_end(self):
         self.request.received_headers['range'] = 'bytes=7991-7999'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
+            lambda r: self.assertEqual(r.headers.get('content-range'),
                                         'bytes 7991-7999/8000'))
 
     def testBodyLength_openEnd(self):
         self.request.received_headers['range'] = 'bytes=7991-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(len(r.v), 9))
+            lambda r: self.assertEqual(len(r.v), 9))
 
     def testBodyContent_openEnd(self):
         self.request.received_headers['range'] = 'bytes=7991-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.v, '123456789'))
+            lambda r: self.assertEqual(r.v, '123456789'))
 
     def testContentLength_openEnd(self):
         self.request.received_headers['range'] = 'bytes=7991-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '9'))
+            lambda r: self.assertEqual(r.headers['content-length'], '9'))
 
     def testContentRange_openEnd(self):
         self.request.received_headers['range'] = 'bytes=7991-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
+            lambda r: self.assertEqual(r.headers.get('content-range'),
                                         'bytes 7991-7999/8000'))
 
     def testBodyLength_fullRange(self):
         self.request.received_headers['range'] = 'bytes=0-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(len(r.v), 8000))
+            lambda r: self.assertEqual(len(r.v), 8000))
 
     def testBodyContent_fullRange(self):
         self.request.received_headers['range'] = 'bytes=0-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.v, 800 * '0123456789'))
+            lambda r: self.assertEqual(r.v, 800 * '0123456789'))
 
     def testContentLength_fullRange(self):
         self.request.received_headers['range'] = 'bytes=0-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers['content-length'], '8000'))
+            lambda r: self.assertEqual(r.headers['content-length'], '8000'))
 
     def testContentRange_fullRange(self):
         self.request.received_headers['range'] = 'bytes=0-'
         return deferredRender(self.file, self.request).addCallback(
-            lambda r: self.assertEquals(r.headers.get('content-range'),
+            lambda r: self.assertEqual(r.headers.get('content-range'),
                                         'bytes 0-7999/8000'))

--- a/nevow/test/test_tags.py
+++ b/nevow/test/test_tags.py
@@ -9,9 +9,9 @@ class TestTags(TestCase):
         foo = tags.directive('foo')
         foo2 = tags.directive('foo')
         bar = tags.directive('bar')
-        self.assertEquals(foo, foo)
-        self.assertEquals(foo, foo2)
-        self.failIfEqual(foo, bar)
+        self.assertEqual(foo, foo)
+        self.assertEqual(foo, foo2)
+        self.assertNotEqual(foo, bar)
 
 
     def test_directiveHashing(self):
@@ -21,8 +21,8 @@ class TestTags(TestCase):
         foo = tags.directive('foo')
         foo2 = tags.directive('foo')
         bar = tags.directive('bar')
-        self.assertEquals(hash(foo), hash(foo2))
+        self.assertEqual(hash(foo), hash(foo2))
 
         # XXX What if 'foo' and 'bar' accidentally hash equal in some version
         # of Python?
-        self.failIfEqual(hash(foo), hash(bar))
+        self.assertNotEqual(hash(foo), hash(bar))

--- a/nevow/test/test_testutil.py
+++ b/nevow/test/test_testutil.py
@@ -109,7 +109,7 @@ class TestFakeRequest(TestCase):
                 root.child('foo'))
 
         def _checkForUrl(result):
-            return self.assertEquals('http://localhost/foo', result)
+            return self.assertEqual('http://localhost/foo', result)
 
         return renderPage(_URLPage()).addCallback(_checkForUrl)
 
@@ -206,7 +206,7 @@ os.kill(os.getpid(), signal.SIGSEGV)
         result = TestResult()
         self.case.run(result)
         self.assertEqual(len(result.errors), 1)
-        self.assertEquals(
+        self.assertEqual(
             result.errors[0][1],
             'Exception: JavaScript interpreter exited due to signal 11\n')
 

--- a/nevow/test/test_testutil.py
+++ b/nevow/test/test_testutil.py
@@ -75,7 +75,7 @@ class TestFakeRequest(TestCase):
         """
         host = 'divmod.com'
         req = FakeRequest()
-        req.setHeader('host', host)
+        req.setHeader(b'host', host)
         self.assertEqual(req.headers['host'], host)
 
 
@@ -137,7 +137,7 @@ class TestFakeRequest(TestCase):
         Test that they are handled separately.
         """
         req = FakeRequest()
-        req.setHeader('foo', 'bar')
+        req.setHeader(b'foo', 'bar')
         self.assertNotIn('foo', req.received_headers)
         self.assertEqual(req.getHeader('foo'), None)
         req.received_headers['foo'] = 'bar'

--- a/nevow/test/test_url.py
+++ b/nevow/test/test_url.py
@@ -5,7 +5,7 @@
 Tests for L{nevow.url}.
 """
 
-import urlparse, urllib
+import urllib.parse, urllib.request, urllib.parse, urllib.error
 
 from nevow import context, url, inevow, util, loaders
 from nevow import tags
@@ -88,7 +88,7 @@ class _IncompatibleSignatureURL(url.URL):
 class TestURL(TestCase):
     def test_fromString(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals(theurl, str(urlpath))
+        self.assertEqual(theurl, str(urlpath))
 
     def test_roundtrip(self):
         tests = (
@@ -108,34 +108,34 @@ class TestURL(TestCase):
             )
         for test in tests:
             result = str(url.URL.fromString(test))
-            self.assertEquals(test, result)
+            self.assertEqual(test, result)
 
     def test_fromRequest(self):
         request = FakeRequest(uri='/a/nice/path/?zot=23&zut',
                               currentSegments=["a", "nice", "path", ""],
                               headers={'host': 'www.foo.com:80'})
         urlpath = url.URL.fromRequest(request)
-        self.assertEquals(theurl, str(urlpath))
+        self.assertEqual(theurl, str(urlpath))
 
     def test_fromContext(self):
 
         r = FakeRequest(uri='/a/b/c')
         urlpath = url.URL.fromContext(context.RequestContext(tag=r))
-        self.assertEquals('http://localhost/', str(urlpath))
+        self.assertEqual('http://localhost/', str(urlpath))
 
         r.prepath = ['a']
         urlpath = url.URL.fromContext(context.RequestContext(tag=r))
-        self.assertEquals('http://localhost/a', str(urlpath))
+        self.assertEqual('http://localhost/a', str(urlpath))
 
         r = FakeRequest(uri='/a/b/c?foo=bar')
         r.prepath = ['a','b']
         urlpath = url.URL.fromContext(context.RequestContext(tag=r))
-        self.assertEquals('http://localhost/a/b?foo=bar', str(urlpath))
+        self.assertEqual('http://localhost/a/b?foo=bar', str(urlpath))
 
     def test_equality(self):
         urlpath = url.URL.fromString(theurl)
-        self.failUnlessEqual(urlpath, url.URL.fromString(theurl))
-        self.failIfEqual(urlpath, url.URL.fromString('ftp://www.anotherinvaliddomain.com/foo/bar/baz/?zot=21&zut'))
+        self.assertEqual(urlpath, url.URL.fromString(theurl))
+        self.assertNotEqual(urlpath, url.URL.fromString('ftp://www.anotherinvaliddomain.com/foo/bar/baz/?zot=21&zut'))
 
 
     def test_fragmentEquality(self):
@@ -148,7 +148,7 @@ class TestURL(TestCase):
 
     def test_parent(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals("http://www.foo.com:80/a/nice/?zot=23&zut",
+        self.assertEqual("http://www.foo.com:80/a/nice/?zot=23&zut",
                           str(urlpath.parent()))
 
 
@@ -167,98 +167,98 @@ class TestURL(TestCase):
 
     def test_parentdir(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals("http://www.foo.com:80/a/nice/?zot=23&zut",
+        self.assertEqual("http://www.foo.com:80/a/nice/?zot=23&zut",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a')
-        self.assertEquals("http://www.foo.com/",
+        self.assertEqual("http://www.foo.com/",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a/')
-        self.assertEquals("http://www.foo.com/",
+        self.assertEqual("http://www.foo.com/",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a/b')
-        self.assertEquals("http://www.foo.com/",
+        self.assertEqual("http://www.foo.com/",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a/b/')
-        self.assertEquals("http://www.foo.com/a/",
+        self.assertEqual("http://www.foo.com/a/",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a/b/c')
-        self.assertEquals("http://www.foo.com/a/",
+        self.assertEqual("http://www.foo.com/a/",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a/b/c/')
-        self.assertEquals("http://www.foo.com/a/b/",
+        self.assertEqual("http://www.foo.com/a/b/",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a/b/c/d')
-        self.assertEquals("http://www.foo.com/a/b/",
+        self.assertEqual("http://www.foo.com/a/b/",
                           str(urlpath.parentdir()))
         urlpath = url.URL.fromString('http://www.foo.com/a/b/c/d/')
-        self.assertEquals("http://www.foo.com/a/b/c/",
+        self.assertEqual("http://www.foo.com/a/b/c/",
                           str(urlpath.parentdir()))
 
     def test_parent_root(self):
         urlpath = url.URL.fromString('http://www.foo.com/')
-        self.assertEquals("http://www.foo.com/",
+        self.assertEqual("http://www.foo.com/",
                           str(urlpath.parentdir()))
-        self.assertEquals("http://www.foo.com/",
+        self.assertEqual("http://www.foo.com/",
                           str(urlpath.parentdir().parentdir()))
 
     def test_child(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals("http://www.foo.com:80/a/nice/path/gong?zot=23&zut",
+        self.assertEqual("http://www.foo.com:80/a/nice/path/gong?zot=23&zut",
                           str(urlpath.child('gong')))
-        self.assertEquals("http://www.foo.com:80/a/nice/path/gong%2F?zot=23&zut",
+        self.assertEqual("http://www.foo.com:80/a/nice/path/gong%2F?zot=23&zut",
                           str(urlpath.child('gong/')))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/gong%2Fdouble?zot=23&zut",
             str(urlpath.child('gong/double')))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/gong%2Fdouble%2F?zot=23&zut",
             str(urlpath.child('gong/double/')))
 
     def test_child_init_tuple(self):
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com/a/b/c",
             str(url.URL(netloc="www.foo.com",
                         pathsegs=['a', 'b']).child("c")))
 
     def test_child_init_root(self):
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com/c",
             str(url.URL(netloc="www.foo.com").child("c")))
 
     def test_sibling(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/sister?zot=23&zut",
             str(urlpath.sibling('sister')))
         # use an url without trailing '/' to check child removal
         theurl2 = "http://www.foo.com:80/a/nice/path?zot=23&zut"
         urlpath = url.URL.fromString(theurl2)
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/sister?zot=23&zut",
             str(urlpath.sibling('sister')))
 
     def test_curdir(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals(theurl, str(urlpath))
+        self.assertEqual(theurl, str(urlpath))
         # use an url without trailing '/' to check object removal
         theurl2 = "http://www.foo.com:80/a/nice/path?zot=23&zut"
         urlpath = url.URL.fromString(theurl2)
-        self.assertEquals("http://www.foo.com:80/a/nice/?zot=23&zut",
+        self.assertEqual("http://www.foo.com:80/a/nice/?zot=23&zut",
                           str(urlpath.curdir()))
 
     def test_click(self):
         urlpath = url.URL.fromString(theurl)
         # a null uri should be valid (return here)
-        self.assertEquals("http://www.foo.com:80/a/nice/path/?zot=23&zut",
+        self.assertEqual("http://www.foo.com:80/a/nice/path/?zot=23&zut",
                           str(urlpath.click("")))
         # a simple relative path remove the query
-        self.assertEquals("http://www.foo.com:80/a/nice/path/click",
+        self.assertEqual("http://www.foo.com:80/a/nice/path/click",
                           str(urlpath.click("click")))
         # an absolute path replace path and query
-        self.assertEquals("http://www.foo.com:80/click",
+        self.assertEqual("http://www.foo.com:80/click",
                           str(urlpath.click("/click")))
         # replace just the query
-        self.assertEquals("http://www.foo.com:80/a/nice/path/?burp",
+        self.assertEqual("http://www.foo.com:80/a/nice/path/?burp",
                           str(urlpath.click("?burp")))
         # one full url to another should not generate '//' between netloc and pathsegs 
         self.failIfIn("//foobar", str(urlpath.click('http://www.foo.com:80/foobar')))
@@ -266,13 +266,13 @@ class TestURL(TestCase):
         # from a url with no query clicking a url with a query,
         # the query should be handled properly
         u = url.URL.fromString('http://www.foo.com:80/me/noquery')
-        self.failUnlessEqual('http://www.foo.com:80/me/17?spam=158',
+        self.assertEqual('http://www.foo.com:80/me/17?spam=158',
                              str(u.click('/me/17?spam=158')))
 
         # Check that everything from the path onward is removed when the click link
         # has no path.
         u = url.URL.fromString('http://localhost/foo?abc=def')
-        self.failUnlessEqual(str(u.click('http://www.python.org')), 'http://www.python.org/')
+        self.assertEqual(str(u.click('http://www.python.org')), 'http://www.python.org/')
 
 
     def test_cloneUnchanged(self):
@@ -383,146 +383,146 @@ class TestURL(TestCase):
             ['http://localhost/a/b/c', 'd//e', 'http://localhost/a/b/d//e'],
             ]
         for start, click, result in tests:
-            self.assertEquals(
+            self.assertEqual(
                 str(url.URL.fromString(start).click(click)),
                 result
                 )
 
     def test_add(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut&burp",
             str(urlpath.add("burp")))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut&burp=xxx",
             str(urlpath.add("burp", "xxx")))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut&burp=xxx&zing",
             str(urlpath.add("burp", "xxx").add("zing")))
         # note the inversion!
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut&zing&burp=xxx",
             str(urlpath.add("zing").add("burp", "xxx")))
         # note the two values for the same name
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut&burp=xxx&zot=32",
             str(urlpath.add("burp", "xxx").add("zot", 32)))
 
     def test_add_noquery(self):
         # fromString is a different code path, test them both
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?foo=bar",
             str(url.URL.fromString("http://www.foo.com:80/a/nice/path/")
                 .add("foo", "bar")))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com/?foo=bar",
             str(url.URL(netloc="www.foo.com").add("foo", "bar")))
 
     def test_replace(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=32&zut",
             str(urlpath.replace("zot", 32)))
         # replace name without value with name/value and vice-versa
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot&zut=itworked",
             str(urlpath.replace("zot").replace("zut", "itworked")))
         # Q: what happens when the query has two values and we replace?
         # A: we replace both values with a single one
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=32&zut",
             str(urlpath.add("zot", "xxx").replace("zot", 32)))
 
     def test_fragment(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut#hiboy",
             str(urlpath.anchor("hiboy")))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut",
             str(urlpath.anchor()))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23&zut",
             str(urlpath.anchor('')))
 
     def test_clear(self):
         urlpath = url.URL.fromString(theurl)
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zut",
             str(urlpath.clear("zot")))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zot=23",
             str(urlpath.clear("zut")))
         # something stranger, query with two values, both should get cleared
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/?zut",
             str(urlpath.add("zot", 1971).clear("zot")))
         # two ways to clear the whole query
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/",
             str(urlpath.clear("zut").clear("zot")))
-        self.assertEquals(
+        self.assertEqual(
             "http://www.foo.com:80/a/nice/path/",
             str(urlpath.clear()))
 
     def test_secure(self):
-        self.assertEquals(str(url.URL.fromString('http://localhost/').secure()), 'https://localhost/')
-        self.assertEquals(str(url.URL.fromString('http://localhost/').secure(True)), 'https://localhost/')
-        self.assertEquals(str(url.URL.fromString('https://localhost/').secure()), 'https://localhost/')
-        self.assertEquals(str(url.URL.fromString('https://localhost/').secure(False)), 'http://localhost/')
-        self.assertEquals(str(url.URL.fromString('http://localhost/').secure(False)), 'http://localhost/')
-        self.assertEquals(str(url.URL.fromString('http://localhost/foo').secure()), 'https://localhost/foo')
-        self.assertEquals(str(url.URL.fromString('http://localhost/foo?bar=1').secure()), 'https://localhost/foo?bar=1')
-        self.assertEquals(str(url.URL.fromString('http://localhost/').secure(port=443)), 'https://localhost/')
-        self.assertEquals(str(url.URL.fromString('http://localhost:8080/').secure(port=8443)), 'https://localhost:8443/')
-        self.assertEquals(str(url.URL.fromString('https://localhost:8443/').secure(False, 8080)), 'http://localhost:8080/')
+        self.assertEqual(str(url.URL.fromString('http://localhost/').secure()), 'https://localhost/')
+        self.assertEqual(str(url.URL.fromString('http://localhost/').secure(True)), 'https://localhost/')
+        self.assertEqual(str(url.URL.fromString('https://localhost/').secure()), 'https://localhost/')
+        self.assertEqual(str(url.URL.fromString('https://localhost/').secure(False)), 'http://localhost/')
+        self.assertEqual(str(url.URL.fromString('http://localhost/').secure(False)), 'http://localhost/')
+        self.assertEqual(str(url.URL.fromString('http://localhost/foo').secure()), 'https://localhost/foo')
+        self.assertEqual(str(url.URL.fromString('http://localhost/foo?bar=1').secure()), 'https://localhost/foo?bar=1')
+        self.assertEqual(str(url.URL.fromString('http://localhost/').secure(port=443)), 'https://localhost/')
+        self.assertEqual(str(url.URL.fromString('http://localhost:8080/').secure(port=8443)), 'https://localhost:8443/')
+        self.assertEqual(str(url.URL.fromString('https://localhost:8443/').secure(False, 8080)), 'http://localhost:8080/')
 
 
     def test_eq_same(self):
         u = url.URL.fromString('http://localhost/')
-        self.failUnless(u == u, "%r != itself" % u)
+        self.assertTrue(u == u, "%r != itself" % u)
 
     def test_eq_similar(self):
         u1 = url.URL.fromString('http://localhost/')
         u2 = url.URL.fromString('http://localhost/')
-        self.failUnless(u1 == u2, "%r != %r" % (u1, u2))
+        self.assertTrue(u1 == u2, "%r != %r" % (u1, u2))
 
     def test_eq_different(self):
         u1 = url.URL.fromString('http://localhost/a')
         u2 = url.URL.fromString('http://localhost/b')
-        self.failIf(u1 == u2, "%r != %r" % (u1, u2))
+        self.assertFalse(u1 == u2, "%r != %r" % (u1, u2))
 
     def test_eq_apples_vs_oranges(self):
         u = url.URL.fromString('http://localhost/')
-        self.failIf(u == 42, "URL must not equal a number.")
-        self.failIf(u == object(), "URL must not equal an object.")
+        self.assertFalse(u == 42, "URL must not equal a number.")
+        self.assertFalse(u == object(), "URL must not equal an object.")
 
     def test_ne_same(self):
         u = url.URL.fromString('http://localhost/')
-        self.failIf(u != u, "%r == itself" % u)
+        self.assertFalse(u != u, "%r == itself" % u)
 
     def test_ne_similar(self):
         u1 = url.URL.fromString('http://localhost/')
         u2 = url.URL.fromString('http://localhost/')
-        self.failIf(u1 != u2, "%r == %r" % (u1, u2))
+        self.assertFalse(u1 != u2, "%r == %r" % (u1, u2))
 
     def test_ne_different(self):
         u1 = url.URL.fromString('http://localhost/a')
         u2 = url.URL.fromString('http://localhost/b')
-        self.failUnless(u1 != u2, "%r == %r" % (u1, u2))
+        self.assertTrue(u1 != u2, "%r == %r" % (u1, u2))
 
     def test_ne_apples_vs_oranges(self):
         u = url.URL.fromString('http://localhost/')
-        self.failUnless(u != 42, "URL must differ from a number.")
-        self.failUnless(u != object(), "URL must be differ from an object.")
+        self.assertTrue(u != 42, "URL must differ from a number.")
+        self.assertTrue(u != object(), "URL must be differ from an object.")
 
     def test_parseEqualInParamValue(self):
         u = url.URL.fromString('http://localhost/?=x=x=x')
-        self.failUnless(u.query == ['=x=x=x'])
-        self.failUnless(str(u) == 'http://localhost/?=x%3Dx%3Dx')
+        self.assertTrue(u.query == ['=x=x=x'])
+        self.assertTrue(str(u) == 'http://localhost/?=x%3Dx%3Dx')
         u = url.URL.fromString('http://localhost/?foo=x=x=x&bar=y')
-        self.failUnless(u.query == ['foo=x=x=x', 'bar=y'])
-        self.failUnless(str(u) == 'http://localhost/?foo=x%3Dx%3Dx&bar=y')
+        self.assertTrue(u.query == ['foo=x=x=x', 'bar=y'])
+        self.assertTrue(str(u) == 'http://localhost/?foo=x%3Dx%3Dx&bar=y')
 
 class Serialization(TestCase):
 
@@ -536,13 +536,13 @@ class Serialization(TestCase):
         u = url.URL(scheme, loc, path, query, fragment)
         s = flatten(url.URL(scheme, loc, path, query, fragment))
 
-        parsedScheme, parsedLoc, parsedPath, parsedQuery, parsedFragment = urlparse.urlsplit(s)
+        parsedScheme, parsedLoc, parsedPath, parsedQuery, parsedFragment = urllib.parse.urlsplit(s)
 
-        self.assertEquals(scheme, parsedScheme)
-        self.assertEquals(loc, parsedLoc)
-        self.assertEquals('/' + '/'.join(map(lambda p: urllib.quote(p,safe=''),path)), parsedPath)
-        self.assertEquals(query, url.unquerify(parsedQuery))
-        self.assertEquals(fragment, parsedFragment)
+        self.assertEqual(scheme, parsedScheme)
+        self.assertEqual(loc, parsedLoc)
+        self.assertEqual('/' + '/'.join([urllib.parse.quote(p,safe='') for p in path]), parsedPath)
+        self.assertEqual(query, url.unquerify(parsedQuery))
+        self.assertEqual(fragment, parsedFragment)
 
     def test_slotQueryParam(self):
         original = 'http://foo/bar?baz=bamf'
@@ -553,7 +553,7 @@ class Serialization(TestCase):
             ctx.fillSlots('param', 5)
             return ctx.tag
 
-        self.assertEquals(flatten(tags.invisible(render=fillIt)[u]), original + '&toot=5')
+        self.assertEqual(flatten(tags.invisible(render=fillIt)[u]), original + '&toot=5')
 
     def test_childQueryParam(self):
         original = 'http://foo/bar'
@@ -564,7 +564,7 @@ class Serialization(TestCase):
             ctx.fillSlots('param', 'baz')
             return ctx.tag
 
-        self.assertEquals(flatten(tags.invisible(render=fillIt)[u]), original + '/baz')
+        self.assertEqual(flatten(tags.invisible(render=fillIt)[u]), original + '/baz')
 
     def test_strangeSegs(self):
         base = 'http://localhost/'
@@ -572,35 +572,35 @@ class Serialization(TestCase):
             (r'/foo/', '%2Ffoo%2F'),
             (r'c:\foo\bar bar', 'c%3A%5Cfoo%5Cbar%20bar'),
             (r'&<>', '%26%3C%3E'),
-            (u'!"\N{POUND SIGN}$%^&*()_+'.encode('utf-8'), '!%22%C2%A3%24%25%5E%26*()_%2B'),
+            ('!"\N{POUND SIGN}$%^&*()_+'.encode('utf-8'), '!%22%C2%A3%24%25%5E%26*()_%2B'),
             )
         for test, result in tests:
             u = url.URL.fromString(base).child(test)
-            self.assertEquals(flatten(u), base+result)
+            self.assertEqual(flatten(u), base+result)
 
     def test_urlContent(self):
         u = url.URL.fromString('http://localhost/').child(r'<c:\foo\bar&>')
-        self.assertEquals(flatten(tags.p[u]), '<p>http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E</p>')
+        self.assertEqual(flatten(tags.p[u]), '<p>http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E</p>')
 
     def test_urlAttr(self):
         u = url.URL.fromString('http://localhost/').child(r'<c:\foo\bar&>')
-        self.assertEquals(flatten(tags.img(src=u)), '<img src="http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E" />')
+        self.assertEqual(flatten(tags.img(src=u)), '<img src="http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E" />')
 
     def test_urlSlot(self):
         u = url.URL.fromString('http://localhost/').child(r'<c:\foo\bar&>')
         tag = tags.img(src=tags.slot('src'))
         tag.fillSlots('src', u)
-        self.assertEquals(flatten(tag), '<img src="http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E" />')
+        self.assertEqual(flatten(tag), '<img src="http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E" />')
 
     def test_urlXmlAttrSlot(self):
         u = url.URL.fromString('http://localhost/').child(r'<c:\foo\bar&>')
         tag = tags.invisible[loaders.xmlstr('<img xmlns:n="http://nevow.com/ns/nevow/0.1" src="#"><n:attr name="src"><n:slot name="src"/></n:attr></img>')]
         tag.fillSlots('src', u)
-        self.assertEquals(flatten(tag), '<img src="http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E" />')
+        self.assertEqual(flatten(tag), '<img src="http://localhost/%3Cc%3A%5Cfoo%5Cbar%26%3E" />')
 
     def test_safe(self):
         u = url.URL.fromString('http://localhost/').child(r"foo-_.!*'()bar")
-        self.assertEquals(flatten(tags.p[u]), r"<p>http://localhost/foo-_.!*'()bar</p>")
+        self.assertEqual(flatten(tags.p[u]), r"<p>http://localhost/foo-_.!*'()bar</p>")
 
     def test_urlintagwithmultipleamps(self):
         """
@@ -610,11 +610,11 @@ class Serialization(TestCase):
         The ampersand must be quoted for the attribute to be valid.
         """
         tag = tags.invisible[tags.a(href=url.URL.fromString('http://localhost/').add('foo', 'bar').add('baz', 'spam'))]
-        self.assertEquals(flatten(tag), '<a href="http://localhost/?foo=bar&amp;baz=spam"></a>')
+        self.assertEqual(flatten(tag), '<a href="http://localhost/?foo=bar&amp;baz=spam"></a>')
 
         tag = tags.invisible[loaders.xmlstr('<a xmlns:n="http://nevow.com/ns/nevow/0.1" href="#"><n:attr name="href"><n:slot name="href"/></n:attr></a>')]
         tag.fillSlots('href', url.URL.fromString('http://localhost/').add('foo', 'bar').add('baz', 'spam'))
-        self.assertEquals(flatten(tag), '<a href="http://localhost/?foo=bar&amp;baz=spam"></a>')
+        self.assertEqual(flatten(tag), '<a href="http://localhost/?foo=bar&amp;baz=spam"></a>')
 
 
     def test_rfc1808(self):
@@ -623,7 +623,7 @@ class Serialization(TestCase):
         base = url.URL.fromString(rfc1808_relative_link_base)
         for link, result in rfc1808_relative_link_tests:
             #print link
-            self.failUnlessEqual(result, flatten(base.click(link)))
+            self.assertEqual(result, flatten(base.click(link)))
     test_rfc1808.todo = 'Many of these fail miserably at the moment; often with a / where there shouldn\'t be'
 
 
@@ -632,9 +632,9 @@ class Serialization(TestCase):
         L{URLSerializer} should provide basic IRI (RFC 3987) support by
         encoding Unicode to UTF-8 before percent-encoding.
         """
-        iri = u'http://localhost/expos\xe9?doppelg\xe4nger=Bryan O\u2019Sullivan#r\xe9sum\xe9'
+        iri = 'http://localhost/expos\xe9?doppelg\xe4nger=Bryan O\u2019Sullivan#r\xe9sum\xe9'
         uri = 'http://localhost/expos%C3%A9?doppelg%C3%A4nger=Bryan%20O%E2%80%99Sullivan#r%C3%A9sum%C3%A9'
-        self.assertEquals(flatten(url.URL.fromString(iri)), uri)
+        self.assertEqual(flatten(url.URL.fromString(iri)), uri)
 
 
 
@@ -652,17 +652,19 @@ class RedirectResource(TestCase):
     def test_urlRedirect(self):
         u = "http://localhost/"
         D = self.renderResource(url.URL.fromString(u))
-        def after((html, redirected_to)):
+        def after(xxx_todo_changeme):
+            (html, redirected_to) = xxx_todo_changeme
             self.assertIn(u, html)
-            self.assertEquals(u, redirected_to)
+            self.assertEqual(u, redirected_to)
         return D.addCallback(after)
 
 
     def test_urlRedirectWithParams(self):
         D = self.renderResource(url.URL.fromString("http://localhost/").child('child').add('foo', 'bar'))
-        def after((html, redirected_to)):
+        def after(xxx_todo_changeme1):
+            (html, redirected_to) = xxx_todo_changeme1
             self.assertIn("http://localhost/child?foo=bar", html)
-            self.assertEquals("http://localhost/child?foo=bar", redirected_to)
+            self.assertEqual("http://localhost/child?foo=bar", redirected_to)
         return D.addCallback(after)
 
 
@@ -671,16 +673,18 @@ class RedirectResource(TestCase):
             url.URL.fromString("http://localhost/")
             .child(util.succeed('child')).add('foo',util.succeed('bar'))
             )
-        def after((html, redirected_to)):
+        def after(xxx_todo_changeme2):
+            (html, redirected_to) = xxx_todo_changeme2
             self.assertIn("http://localhost/child?foo=bar", html)
-            self.assertEquals("http://localhost/child?foo=bar", redirected_to)
+            self.assertEqual("http://localhost/child?foo=bar", redirected_to)
         return D.addCallback(after)
 
 
     def test_deferredURLOverlayParam(self):
         D = self.renderResource(url.here.child(util.succeed('child')).add('foo',util.succeed('bar')))
-        def after((html, redirected_to)):
+        def after(xxx_todo_changeme3):
+            (html, redirected_to) = xxx_todo_changeme3
             self.assertIn("http://localhost/child?foo=bar", html)
-            self.assertEquals("http://localhost/child?foo=bar", redirected_to)
+            self.assertEqual("http://localhost/child?foo=bar", redirected_to)
         return D.addCallback(after)
 

--- a/nevow/test/test_utils.py
+++ b/nevow/test/test_utils.py
@@ -30,8 +30,8 @@ class ExposeTestCase(TestCase):
                 return 'baz'
             expose(bar)
 
-        self.assertEquals(list(expose.exposedMethodNames(Foo())), ['bar'])
-        self.assertEquals(expose.get(Foo(), 'bar')(), 'baz')
+        self.assertEqual(list(expose.exposedMethodNames(Foo())), ['bar'])
+        self.assertEqual(expose.get(Foo(), 'bar')(), 'baz')
 
 
     def test_multipleExposeCalls(self):
@@ -51,9 +51,9 @@ class ExposeTestCase(TestCase):
             expose(quux)
 
 
-        self.assertEquals(list(expose.exposedMethodNames(Foo())), ['bar', 'quux'])
-        self.assertEquals(expose.get(Foo(), 'bar')(), 'baz')
-        self.assertEquals(expose.get(Foo(), 'quux')(), 'fooble')
+        self.assertEqual(list(expose.exposedMethodNames(Foo())), ['bar', 'quux'])
+        self.assertEqual(expose.get(Foo(), 'bar')(), 'baz')
+        self.assertEqual(expose.get(Foo(), 'quux')(), 'fooble')
 
 
     def test_multipleExposeArguments(self):
@@ -72,9 +72,9 @@ class ExposeTestCase(TestCase):
 
             expose(bar, quux)
 
-        self.assertEquals(list(expose.exposedMethodNames(Foo())), ['bar', 'quux'])
-        self.assertEquals(expose.get(Foo(), 'bar')(), 'baz')
-        self.assertEquals(expose.get(Foo(), 'quux')(), 'fooble')
+        self.assertEqual(list(expose.exposedMethodNames(Foo())), ['bar', 'quux'])
+        self.assertEqual(expose.get(Foo(), 'bar')(), 'baz')
+        self.assertEqual(expose.get(Foo(), 'quux')(), 'fooble')
 
 
     def test_inheritanceExpose(self):
@@ -92,7 +92,7 @@ class ExposeTestCase(TestCase):
             def bar(self):
                 return 'BAZ'
 
-        self.assertEquals(list(expose.exposedMethodNames(Quux())), [])
+        self.assertEqual(list(expose.exposedMethodNames(Quux())), [])
         self.assertRaises(UnexposedMethodError, expose.get, Quux(), 'bar')
 
 
@@ -112,8 +112,8 @@ class ExposeTestCase(TestCase):
                 return 'smokey'
             expose(bar)
 
-        self.assertEquals(list(expose.exposedMethodNames(Quux())), ['bar'])
-        self.assertEquals(expose.get(Quux(), 'bar')(), 'smokey')
+        self.assertEqual(list(expose.exposedMethodNames(Quux())), ['bar'])
+        self.assertEqual(expose.get(Quux(), 'bar')(), 'smokey')
 
 
     def test_inheritanceExposeMore(self):
@@ -137,12 +137,12 @@ class ExposeTestCase(TestCase):
                 return 'alligator'
             expose(smokey, pogo)
 
-        self.assertEquals(set(expose.exposedMethodNames(Quux())), set(['pogo', 'smokey', 'bar']))
-        self.assertEquals(expose.get(Quux(), 'bar')(), 'baz')
-        self.assertEquals(expose.get(Quux(), 'smokey')(), 'stover')
-        self.assertEquals(expose.get(Quux(), 'pogo')(), 'kelly')
+        self.assertEqual(set(expose.exposedMethodNames(Quux())), set(['pogo', 'smokey', 'bar']))
+        self.assertEqual(expose.get(Quux(), 'bar')(), 'baz')
+        self.assertEqual(expose.get(Quux(), 'smokey')(), 'stover')
+        self.assertEqual(expose.get(Quux(), 'pogo')(), 'kelly')
         self.assertRaises(UnexposedMethodError, expose.get, Quux(), 'albert')
-        self.assertEquals(Quux().albert(), 'alligator')
+        self.assertEqual(Quux().albert(), 'alligator')
 
 
     def test_multipleInheritanceExpose(self):
@@ -167,9 +167,9 @@ class ExposeTestCase(TestCase):
                 pass
             expose(quux)
 
-        self.assertEquals(set(expose.exposedMethodNames(C())), set(['quux', 'foo', 'baz']))
-        self.assertEquals(expose.get(C(), 'foo')(), 'bar')
-        self.assertEquals(expose.get(C(), 'baz')(), 'quux')
+        self.assertEqual(set(expose.exposedMethodNames(C())), set(['quux', 'foo', 'baz']))
+        self.assertEqual(expose.get(C(), 'foo')(), 'bar')
+        self.assertEqual(expose.get(C(), 'baz')(), 'quux')
 
 
     def test_multipleInheritanceExposeWithoutSubclassCall(self):
@@ -192,9 +192,9 @@ class ExposeTestCase(TestCase):
         class C(A, B):
             pass
 
-        self.assertEquals(set(expose.exposedMethodNames(C())), set(['foo', 'baz']))
-        self.assertEquals(expose.get(C(), 'foo')(), 'bar')
-        self.assertEquals(expose.get(C(), 'baz')(), 'quux')
+        self.assertEqual(set(expose.exposedMethodNames(C())), set(['foo', 'baz']))
+        self.assertEqual(expose.get(C(), 'foo')(), 'bar')
+        self.assertEqual(expose.get(C(), 'baz')(), 'quux')
 
 
     def test_unexposedMethodInaccessable(self):
@@ -224,8 +224,8 @@ class ExposeTestCase(TestCase):
                 return 'bar'
             expose(foo)
 
-        self.assertEquals(expose.get(A(), 'foo', None)(), 'bar')
-        self.assertEquals(expose.get(A(), 'bar', None), None)
+        self.assertEqual(expose.get(A(), 'foo', None)(), 'bar')
+        self.assertEqual(expose.get(A(), 'bar', None), None)
 
 
     def test_exposeReturnValue(self):
@@ -268,11 +268,11 @@ class ExposeTestCase(TestCase):
                 return 'quux'
             expose(quux)
 
-        self.assertEquals(
+        self.assertEqual(
             set(expose.exposedMethodNames(Foo())),
             set(['bar', 'quux']))
-        self.assertEquals(expose.get(Foo(), 'bar')(), 'baz')
-        self.assertEquals(expose.get(Foo(), 'quux')(), 'quux')
+        self.assertEqual(expose.get(Foo(), 'bar')(), 'baz')
+        self.assertEqual(expose.get(Foo(), 'quux')(), 'quux')
 
 
 
@@ -282,7 +282,7 @@ class CachedFileTests(TestCase):
         file(self.testFile, 'w').close()
 
         counter = count()
-        self.cache = CachedFile(self.testFile, lambda path: counter.next())
+        self.cache = CachedFile(self.testFile, lambda path: next(counter))
 
     def test_cache(self):
         """
@@ -341,7 +341,7 @@ class CachedFileTests(TestCase):
         def _loadMe(path, crashMe=False):
             if crashMe:
                 raise Exception('It is an exception!')
-            return counter.next()
+            return next(counter)
 
         cf = CachedFile(self.testFile, _loadMe)
 

--- a/nevow/testutil.py
+++ b/nevow/testutil.py
@@ -116,7 +116,7 @@ class FakeRequest(Componentized):
         self.site = FakeSite()
         self.received_headers = {}
         if headers:
-            for k, v in headers.iteritems():
+            for k, v in headers.items():
                 self.received_headers[k.lower()] = v
         if cookies is not None:
             self.cookies = cookies
@@ -472,7 +472,7 @@ Divmod.UnitTest.runRemote(Divmod.UnitTest.loadFromModule(%(module)s));
     def run(self, result):
         try:
             self.checkDependencies()
-        except NotSupported, e:
+        except NotSupported as e:
             result.startTest(self)
             result.addSkip(self, str(e))
             result.stopTest(self)
@@ -553,7 +553,7 @@ class CSSModuleTestMixin:
             return fname
 
         return athena.CSSRegistry(
-            {u'TestCSSModuleDependencies': makeModule(),
-             u'TestCSSModuleDependencies.Dependor': makeModule(
+            {'TestCSSModuleDependencies': makeModule(),
+             'TestCSSModuleDependencies.Dependor': makeModule(
                 '// import TestCSSModuleDependencies.Dependee\n'),
-             u'TestCSSModuleDependencies.Dependee': makeModule()})
+             'TestCSSModuleDependencies.Dependee': makeModule()})

--- a/nevow/testutil.py
+++ b/nevow/testutil.py
@@ -6,7 +6,7 @@ import os, sys, signal
 
 from subprocess import PIPE, Popen
 
-from zope.interface import implements
+from zope.interface import implementer
 
 try:
     import subunit
@@ -33,9 +33,8 @@ class FakeChannel:
 class FakeSite:
     pass
 
-
+@implementer(inevow.ISession)
 class FakeSession(Componentized):
-    implements(inevow.ISession)
     def __init__(self, avatar):
         Componentized.__init__(self)
         self.avatar = avatar
@@ -46,7 +45,7 @@ class FakeSession(Componentized):
 
 fs = FakeSession(None)
 
-
+@implementer(inevow.IRequest)
 class FakeRequest(Componentized):
     """
     Implementation of L{inevow.IRequest} which is convenient to use in unit
@@ -65,7 +64,6 @@ class FakeRequest(Componentized):
 
     @ivar _appRootURL: C{None} or the object passed to L{rememberRootURL}.
     """
-    implements(inevow.IRequest)
 
     fields = None
     failure = None
@@ -285,7 +283,7 @@ if not hasattr(TrialTestCase, 'mktemp'):
         return tempfile.mktemp()
     TestCase.mktemp = mktemp
 
-
+@implementer(inevow.IFormDefaults)
 class AccumulatingFakeRequest(FakeRequest):
     """
     I am a fake IRequest that is also a stub implementation of
@@ -294,7 +292,6 @@ class AccumulatingFakeRequest(FakeRequest):
     This class is named I{accumulating} for historical reasons only.  You
     probably want to ignore this and use L{FakeRequest} instead.
     """
-    implements(iformless.IFormDefaults)
 
     def __init__(self, *a, **kw):
         FakeRequest.__init__(self, *a, **kw)

--- a/nevow/testutil.py
+++ b/nevow/testutil.py
@@ -24,6 +24,7 @@ from formless import iformless
 
 from nevow import inevow, context, athena, loaders, tags, appserver
 from nevow.jsutil import findJavascriptInterpreter, generateTestScript
+from nevow.util import unicode, toBytes
 
 class FakeChannel:
     def __init__(self, site):
@@ -190,8 +191,8 @@ class FakeRequest(Componentized):
 
         @rtype: C{str}.
         """
-        return 'http://%s/%s' % (self.getHeader('host') or 'localhost',
-                                 '/'.join(self.prepath))
+        return 'http://%s/%s' % (unicode(self.getHeader('host')) or 'localhost',
+                                 unicode(b'/'.join(self.prepath)))
 
     def getClientIP(self):
         return '127.0.0.1'

--- a/nevow/testutil.py
+++ b/nevow/testutil.py
@@ -283,7 +283,7 @@ if not hasattr(TrialTestCase, 'mktemp'):
         return tempfile.mktemp()
     TestCase.mktemp = mktemp
 
-@implementer(inevow.IFormDefaults)
+@implementer(iformless.IFormDefaults)
 class AccumulatingFakeRequest(FakeRequest):
     """
     I am a fake IRequest that is also a stub implementation of

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -129,7 +129,7 @@ class URL(object):
         u = klass(
             scheme, netloc,
             [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]],
-            unquerify(query), urllib.parse.unquote(fragment))
+            unquerify(toBytes(query)), urllib.parse.unquote(toBytes(fragment)))
         return u
     fromString = classmethod(fromString)
 

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -126,11 +126,11 @@ class URL(object):
 
     def fromString(klass, st):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
-        print(131, [toBytes(seg) for seg in toBytes(path).split(b'/')[1:]])
+        print(131, [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]])
         u = klass(
             scheme, netloc,
             
-            [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]],
+            [ for seg in toBytes(path).split(b'/')[1:]],
             unquerify(toBytes(query)), urllib.parse.unquote(toBytes(fragment)))
         return u
     fromString = classmethod(fromString)

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -18,7 +18,7 @@ from nevow import inevow, flat
 from nevow.stan import raw
 from nevow.flat import serialize
 from nevow.context import WovenContext
-from nevow.utils import unicode, toBytes
+from nevow.util import unicode, toBytes
 
 def _uqf(query):
     for x in query.split('&'):

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -131,7 +131,7 @@ class URL(object):
             scheme, netloc,
             
             [urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]],
-            unquerify(toBytes(query)), urllib.parse.unquote(toBytes(fragment)))
+            unquerify(toBytes(query)), urllib.parse.unquote(unicode(fragment)))
         return u
     fromString = classmethod(fromString)
 

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -128,6 +128,7 @@ class URL(object):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
         u = klass(
             scheme, netloc,
+            print(131, [toBytes(seg) for seg in toBytes(path).split(b'/')[1:]])
             [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]],
             unquerify(toBytes(query)), urllib.parse.unquote(toBytes(fragment)))
         return u

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -182,6 +182,8 @@ class URL(object):
         """Construct a url where the given path segment is a child of this url
         """
         l = self.pathList()
+        if not l:
+            l=[path]
         if l[-1] == '':
             l[-1] = path
         else:

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -374,6 +374,7 @@ class URL(object):
     ## object protocol override ##
 
     def __str__(self):
+        print(377,flat.flatten(self))
         return str(flat.flatten(self))
 
     def __repr__(self):

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -21,6 +21,7 @@ from nevow.context import WovenContext
 from nevow.util import unicode, toBytes
 
 def _uqf(query):
+    query=unicode(query)
     for x in query.split('&'):
         if '=' in x:
             yield tuple( [urllib.parse.unquote_plus(s) for s in x.split('=', 1)] )

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -556,7 +556,7 @@ def URLOverlaySerializer(original, context):
         for key in original._keep:
             for value in req.args.get(key, []):
                 url = url.add(key, value)
-        yield b''.join(serialize(url, context))
+        yield toBytes(''.join(serialize(url, context)))
 
 
 ## This is totally unfinished and doesn't work yet.

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -128,7 +128,7 @@ class URL(object):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
         u = klass(
             scheme, netloc,
-            [urllib.parse.unquote(toBytes(seg)) for seg in path.split('/')[1:]],
+            [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]],
             unquerify(query), urllib.parse.unquote(fragment))
         return u
     fromString = classmethod(fromString)

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -126,9 +126,10 @@ class URL(object):
 
     def fromString(klass, st):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
+        print(131, [toBytes(seg) for seg in toBytes(path).split(b'/')[1:]])
         u = klass(
             scheme, netloc,
-            print(131, [toBytes(seg) for seg in toBytes(path).split(b'/')[1:]])
+            
             [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]],
             unquerify(toBytes(query)), urllib.parse.unquote(toBytes(fragment)))
         return u

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -130,7 +130,7 @@ class URL(object):
         u = klass(
             scheme, netloc,
             
-            [ for seg in toBytes(path).split(b'/')[1:]],
+            [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]],
             unquerify(toBytes(query)), urllib.parse.unquote(toBytes(fragment)))
         return u
     fromString = classmethod(fromString)

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -18,6 +18,7 @@ from nevow import inevow, flat
 from nevow.stan import raw
 from nevow.flat import serialize
 from nevow.context import WovenContext
+from nevow.utils import unicode, toBytes
 
 def _uqf(query):
     for x in query.split('&'):
@@ -148,10 +149,11 @@ class URL(object):
         '''Create a URL object that represents the current URL in the traversal
         process.'''
         request = inevow.IRequest(context)
-        uri = request.prePathURL()
-        if '?' in request.uri:
-            uri += '?' + request.uri.split('?')[-1]
-        return klass.fromString(uri)
+        request.prepath=[toBytes(i) for i in request.prepath]
+        uri = toBytes(request.prePathURL())
+        if b'?' in toBytes(request.uri):
+            uri += b'?' + toBytes(request.uri).split(b'?')[-1]
+        return klass.fromString(unicode(uri))
     fromContext = classmethod(fromContext)
 
     ## path manipulations ##

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -131,7 +131,7 @@ class URL(object):
         u = klass(
             scheme, netloc,
             
-            [urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]],
+            b''.join([urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]]),
             unquerify(toBytes(query)), urllib.parse.unquote(unicode(fragment)))
         print(135, u)
         return u

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -126,11 +126,10 @@ class URL(object):
 
     def fromString(klass, st):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
-        print(131, [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]])
         u = klass(
             scheme, netloc,
             
-            [urllib.parse.unquote(toBytes(seg)) for seg in toBytes(path).split(b'/')[1:]],
+            [urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]],
             unquerify(toBytes(query)), urllib.parse.unquote(toBytes(fragment)))
         return u
     fromString = classmethod(fromString)

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -127,11 +127,13 @@ class URL(object):
 
     def fromString(klass, st):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
+        print(130, st)
         u = klass(
             scheme, netloc,
             
             [urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]],
             unquerify(toBytes(query)), urllib.parse.unquote(unicode(fragment)))
+        print(135, u)
         return u
     fromString = classmethod(fromString)
 

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -10,7 +10,7 @@ import weakref
 import urllib.parse
 import urllib.request, urllib.parse, urllib.error
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.web.util import redirectTo
 
@@ -585,7 +585,7 @@ class URLGenerator:
         self.__dict__ = state
         self._objmap = weakref.WeakKeyDictionary()
 
-
+@implementer(inevow.IResource)
 class URLRedirectAdapter:
     """
     Adapter for URL and URLOverlay instances that results in an HTTP
@@ -610,7 +610,6 @@ class URLRedirectAdapter:
             # Redirect to the URL of this resource
             return url.URL.fromContext(ctx)
     """
-    implements(inevow.IResource)
 
     def __init__(self, original):
         self.original = original

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -166,8 +166,6 @@ class URL(object):
             result = list(map(urllib.parse.unquote, result))
         if copy:
             result = result[:]
-        if isinstance(result, (str, bytes)):
-            return [result]
         return result
 
     def sibling(self, path):
@@ -255,13 +253,12 @@ class URL(object):
             return self
 
         query = unquerify(query)
-        if isinstance(path, bytes):
-            path=path.decode('charmap')
+
         if scheme:
             if path and path[0] == '/':
                 path = path[1:]
             return self.cloneURL(
-                scheme, netloc, list(map(raw, path.encode('charmap').split(b'/'))), query, fragment)
+                scheme, netloc, list(map(raw, path.split('/'))), query, fragment)
         else:
             scheme = self.scheme
 
@@ -560,7 +557,7 @@ def URLOverlaySerializer(original, context):
         for key in original._keep:
             for value in req.args.get(key, []):
                 url = url.add(key, value)
-        yield toBytes(b''.join([toBytes(b) for b in serialize(url, context)]))
+        yield toBytes(b''.join(serialize(url, context)))
 
 
 ## This is totally unfinished and doesn't work yet.
@@ -633,12 +630,9 @@ class URLRedirectAdapter:
         bits = []
         def flattened(spam):
             # Join the bits to make a complete URL.
-            print(635)
-            u = (b''.join([bytes(b) for b in bits]))
+            u = ''.join(bits)
             # It might also be relative so resolve it against the current URL
             # and flatten it again.
-            print(639, u)
             u = flat.flatten(URL.fromContext(ctx).click(u), ctx)
-            print(639, u)
             return redirectTo(u, inevow.IRequest(ctx))
         return flat.flattenFactory(self.original, ctx, bits.append, flattened)

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -557,7 +557,7 @@ def URLOverlaySerializer(original, context):
         for key in original._keep:
             for value in req.args.get(key, []):
                 url = url.add(key, value)
-        print(560,url)
+        print(560,url, serialize(url, context))
         yield serialize(url, context)
 
 

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -550,12 +550,14 @@ def URLOverlaySerializer(original, context):
         yield original
     else:
         url = original.urlaccessor(context)
+        print(553,url)
         for (cmd, args, kw) in original.dolater:
             url = getattr(url, cmd)(*args, **kw)
         req = context.locate(inevow.IRequest)
         for key in original._keep:
             for value in req.args.get(key, []):
                 url = url.add(key, value)
+        print(560,url)
         yield serialize(url, context)
 
 

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -127,13 +127,11 @@ class URL(object):
 
     def fromString(klass, st):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
-        print(130, scheme, netloc, path, query, fragment)
         u = klass(
             scheme, netloc,
             
             toBytes(''.join([urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]])),
             unquerify(toBytes(query)), urllib.parse.unquote(unicode(fragment)))
-        print(135, u)
         return u
     fromString = classmethod(fromString)
 
@@ -146,7 +144,6 @@ class URL(object):
         uri = request.prePathURL()
         if '?' in request.uri:
             uri += '?' + request.uri.split('?')[-1]
-        print(147, klass.fromString(uri))
         return klass.fromString(uri)
     fromRequest = classmethod(fromRequest)
 
@@ -374,7 +371,6 @@ class URL(object):
     ## object protocol override ##
 
     def __str__(self):
-        print(377,flat.flatten(self))
         return str(flat.flatten(self))
 
     def __repr__(self):

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -550,15 +550,13 @@ def URLOverlaySerializer(original, context):
         yield original
     else:
         url = original.urlaccessor(context)
-        print(553,url)
         for (cmd, args, kw) in original.dolater:
             url = getattr(url, cmd)(*args, **kw)
         req = context.locate(inevow.IRequest)
         for key in original._keep:
             for value in req.args.get(key, []):
                 url = url.add(key, value)
-        print(560,url, list(serialize(url, context)))
-        yield serialize(url, context)
+        yield b''.join(serialize(url, context))
 
 
 ## This is totally unfinished and doesn't work yet.

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -144,6 +144,7 @@ class URL(object):
         uri = request.prePathURL()
         if '?' in request.uri:
             uri += '?' + request.uri.split('?')[-1]
+        print(147, klass.fromString(uri))
         return klass.fromString(uri)
     fromRequest = classmethod(fromRequest)
 

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -561,7 +561,7 @@ def URLOverlaySerializer(original, context):
         for key in original._keep:
             for value in req.args.get(key, []):
                 url = url.add(key, value)
-        yield toBytes(''.join(serialize(url, context)))
+        yield toBytes(b''.join(serialize(url, context)))
 
 
 ## This is totally unfinished and doesn't work yet.

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -557,7 +557,7 @@ def URLOverlaySerializer(original, context):
         for key in original._keep:
             for value in req.args.get(key, []):
                 url = url.add(key, value)
-        print(560,url, serialize(url, context))
+        print(560,url, list(serialize(url, context)))
         yield serialize(url, context)
 
 

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -128,7 +128,7 @@ class URL(object):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
         u = klass(
             scheme, netloc,
-            [urllib.parse.unquote(seg) for seg in path.split('/')[1:]],
+            [urllib.parse.unquote(toBytes(seg)) for seg in path.split('/')[1:]],
             unquerify(query), urllib.parse.unquote(fragment))
         return u
     fromString = classmethod(fromString)

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -131,7 +131,7 @@ class URL(object):
         u = klass(
             scheme, netloc,
             
-            b''.join([urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]]),
+            toBytes(''.join([urllib.parse.unquote(unicode(seg)) for seg in unicode(path).split('/')[1:]])),
             unquerify(toBytes(query)), urllib.parse.unquote(unicode(fragment)))
         print(135, u)
         return u

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -127,7 +127,7 @@ class URL(object):
 
     def fromString(klass, st):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(st)
-        print(130, st)
+        print(130, scheme, netloc, path, query, fragment)
         u = klass(
             scheme, netloc,
             

--- a/nevow/url.py
+++ b/nevow/url.py
@@ -524,29 +524,29 @@ def URLSerializer(original, context):
     urlContext = WovenContext(parent=context, precompile=context.precompile, inURL=True)
     if original.scheme:
         # TODO: handle Unicode (see #2409)
-        yield "%s://%s" % (original.scheme, original.netloc)
+        yield b"%s://%s" % (toBytes(original.scheme), toBytes(original.netloc))
     for pathsegment in original._qpathlist:
-        yield '/'
+        yield b'/'
         yield serialize(_maybeEncode(pathsegment), urlContext)
     query = original._querylist
     if query:
-        yield '?'
+        yield b'?'
         first = True
         for key, value in query:
             if not first:
                 # xhtml can't handle unescaped '&'
                 if context.isAttrib is True:
-                    yield '&amp;'
+                    yield b'&amp;'
                 else:
-                    yield '&'
+                    yield b'&'
             else:
                 first = False
             yield serialize(_maybeEncode(key), urlContext)
             if value is not None:
-                yield '='
+                yield b'='
                 yield serialize(_maybeEncode(value), urlContext)
     if original.fragment:
-        yield "#"
+        yield b"#"
         yield serialize(_maybeEncode(original.fragment), urlContext)
 
 

--- a/nevow/useragent.py
+++ b/nevow/useragent.py
@@ -28,10 +28,10 @@ class browsers(object):
     """
     Namespace class for Browser identifiers.
     """
-    GECKO = u'gecko'
-    INTERNET_EXPLORER = u'internet explorer'
-    WEBKIT = u'webkit'
-    OPERA = u'opera'
+    GECKO = 'gecko'
+    INTERNET_EXPLORER = 'internet explorer'
+    WEBKIT = 'webkit'
+    OPERA = 'opera'
 
 
 class UserAgent(object):
@@ -97,7 +97,7 @@ class UserAgent(object):
                 end += 1
             version = agentString[start + len(identifier):end]
             try:
-                version = map(int, version.split('.'))
+                version = list(map(int, version.split('.')))
             except ValueError:
                 pass
             else:
@@ -113,7 +113,7 @@ class UserAgent(object):
         if agentString.startswith(prefix):
             version = agentString[len(prefix):].split(None, 1)[0]
             try:
-                version = map(int, version.split('.'))
+                version = list(map(int, version.split('.')))
             except ValueError:
                 pass
             else:
@@ -134,7 +134,7 @@ class UserAgent(object):
                     end = None
                 version = agentString[len(prefix):end]
                 try:
-                    version = map(int, version.split('.'))
+                    version = list(map(int, version.split('.')))
                 except ValueError:
                     pass
                 else:

--- a/nevow/util.py
+++ b/nevow/util.py
@@ -170,15 +170,15 @@ class _NamedAnyError(Exception):
     'Internal error for when importing fails.'
 
 def _namedAnyWithBuiltinTranslation(name):
-    if name == '__builtin__.function':
+    if name == 'builtins.function':
         name='types.FunctionType'
-    elif name == '__builtin__.method':
+    elif name == 'builtins.method':
         return _RandomClazz # Hack
-    elif name == '__builtin__.instancemethod':
+    elif name == 'builtins.instancemethod':
         name='types.MethodType'
-    elif name == '__builtin__.NoneType':
+    elif name == 'builtins.NoneType':
         name='types.NoneType'
-    elif name == '__builtin__.generator':
+    elif name == 'builtins.generator':
         name='types.GeneratorType'
     return namedAny(name)
 

--- a/nevow/util.py
+++ b/nevow/util.py
@@ -244,3 +244,12 @@ class CachedFile(object):
             self._mtime = currentTime
 
         return self._cachedObj
+        
+        
+def getEncoding(path):
+     with subprocess.Popen(['file', '-b', '--mime-encoding', path], stdout=subprocess.PIPE) as t:
+         t.wait()
+         encoding = t.stdout.read().strip().decode('charmap')
+         if encoding == 'binary':
+             encoding = 'charmap'
+         return encoding

--- a/nevow/util.py
+++ b/nevow/util.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2004 Divmod.
 # See LICENSE for details.
 
-import inspect, os.path
+import inspect, os.path, subprocess
 
 def toBytes(obj, codec='utf-8'):
     if isinstance(obj, str):

--- a/nevow/util.py
+++ b/nevow/util.py
@@ -3,6 +3,21 @@
 
 import inspect, os.path
 
+def toBytes(obj, codec='utf-8'):
+    if isinstance(obj, str):
+        return obj.encode(codec)
+    if isinstance(obj, bytes):
+        return obj
+    return str(obj).encode(codec)
+
+def unicode(obj, codec='utf-8'):
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, bytes):
+        return obj.decode(codec)
+    return str(obj)
+
+
 class UnexposedMethodError(Exception):
     """
     Raised on any attempt to get a method which has not been exposed.

--- a/nevow/vhost.py
+++ b/nevow/vhost.py
@@ -2,7 +2,7 @@
 # See LICENSE for details.
 
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 from nevow import loaders, rend, inevow
 from nevow.stan import directive
 from nevow import tags
@@ -128,12 +128,12 @@ class NameVirtualHost(rend.Page):
         resrc = self._getResourceForRequest(inevow.IRequest(ctx))
         return resrc, segments
 
+@implementer(inevow.IResource)
 class _VHostMonsterResourcePrepathCleaner:
     """VHostMonsterResource cannot modify request.prepath because the
     segments it needs to remove are not appended to prepath until
     *after* it returns the (resource,segments) tuple.
     """
-    implements(inevow.IResource)
     def locateChild(self, ctx, segments):
         request = inevow.IRequest(ctx)
         request.prepath = request.prepath[3:]
@@ -141,6 +141,7 @@ class _VHostMonsterResourcePrepathCleaner:
 
 _prepathCleaner = _VHostMonsterResourcePrepathCleaner()
 
+@implementer(inevow.IResource)
 class VHostMonsterResource:
     """VHostMonster resource that helps to deploy a Nevow site behind a proxy.
     
@@ -178,7 +179,6 @@ class VHostMonsterResource:
     host name they are contacting. This can lead to cookie stealing or
     cross site scripting attacks. Never expose /vhost to the Internet.
     """
-    implements(inevow.IResource)
 
     def locateChild(self, ctx, segments):
 

--- a/nevow/vhost.py
+++ b/nevow/vhost.py
@@ -21,7 +21,7 @@ class VirtualHostList(rend.Page):
         return self.stylesheet
  
     def data_hostlist(self, context, data):
-        return self.nvh.hosts.keys()
+        return list(self.nvh.hosts.keys())
 
     def render_hostlist(self, context, data):
         host=data
@@ -115,7 +115,7 @@ class NameVirtualHost(rend.Page):
                     found.
                 """
 
-                while not self.hosts.has_key(host) and len(host.split('.')) > 1:
+                while host not in self.hosts and len(host.split('.')) > 1:
                     host = '.'.join(host.split('.')[1:])
 
         return (self.hosts.get(host, self.default) or rend.NotFound[0])

--- a/versioneer.py
+++ b/versioneer.py
@@ -466,19 +466,19 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
             if e.errno == errno.ENOENT:
                 continue
             if verbose:
-                print("unable to run %s" % args[0])
+                print(("unable to run %s" % args[0]))
                 print(e)
             return None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(("unable to find command, tried %s" % (commands,)))
         return None
     stdout = p.communicate()[0].strip()
     if sys.version >= '3':
         stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % args[0])
+            print(("unable to run %s (error)" % args[0]))
         return None
     return stdout
 
@@ -530,15 +530,15 @@ def versions_from_expanded_variables(variables, tag_prefix, verbose=False):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs-tags))
+            print(("discarding '%s', no digits" % ",".join(refs-tags)))
     if verbose:
-        print("likely tags: %s" % ",".join(sorted(tags)))
+        print(("likely tags: %s" % ",".join(sorted(tags))))
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
             if verbose:
-                print("picking %s" % r)
+                print(("picking %s" % r))
             return { "version": r,
                      "full": variables["full"].strip() }
     # no suitable tags, so we use the full revision id
@@ -555,7 +555,7 @@ def versions_from_vcs(tag_prefix, root, verbose=False):
 
     if not os.path.exists(os.path.join(root, ".git")):
         if verbose:
-            print("no .git in %s" % root)
+            print(("no .git in %s" % root))
         return {}
 
     GITS = ["git"]
@@ -567,7 +567,7 @@ def versions_from_vcs(tag_prefix, root, verbose=False):
         return {}
     if not stdout.startswith(tag_prefix):
         if verbose:
-            print("tag '%s' doesn't start with prefix '%s'" % (stdout, tag_prefix))
+            print(("tag '%s' doesn't start with prefix '%s'" % (stdout, tag_prefix)))
         return {}
     tag = stdout[len(tag_prefix):]
     stdout = run_command(GITS, ["rev-parse", "HEAD"], cwd=root)
@@ -585,8 +585,8 @@ def versions_from_parentdir(parentdir_prefix, root, verbose=False):
     dirname = os.path.basename(root)
     if not dirname.startswith(parentdir_prefix):
         if verbose:
-            print("guessing rootdir is '%s', but '%s' doesn't start with prefix '%s'" %
-                  (root, dirname, parentdir_prefix))
+            print(("guessing rootdir is '%s', but '%s' doesn't start with prefix '%s'" %
+                  (root, dirname, parentdir_prefix)))
         return None
     return {"version": dirname[len(parentdir_prefix):], "full": ""}
 import os.path
@@ -675,7 +675,7 @@ def write_to_version_file(filename, versions):
     f = open(filename, "w")
     f.write(SHORT_VERSION_PY % versions)
     f.close()
-    print("set %s to '%s'" % (filename, versions["version"]))
+    print(("set %s to '%s'" % (filename, versions["version"])))
 
 def get_root():
     try:
@@ -706,25 +706,25 @@ def get_versions(default=DEFAULT, verbose=False):
     if variables:
         ver = versions_from_expanded_variables(variables, tag_prefix)
         if ver:
-            if verbose: print("got version from expanded variable %s" % ver)
+            if verbose: print(("got version from expanded variable %s" % ver))
             return ver
 
     ver = versions_from_file(versionfile_abs)
     if ver:
-        if verbose: print("got version from file %s %s" % (versionfile_abs,ver))
+        if verbose: print(("got version from file %s %s" % (versionfile_abs,ver)))
         return ver
 
     ver = versions_from_vcs(tag_prefix, root, verbose)
     if ver:
-        if verbose: print("got version from git %s" % ver)
+        if verbose: print(("got version from git %s" % ver))
         return ver
 
     ver = versions_from_parentdir(parentdir_prefix, root, verbose)
     if ver:
-        if verbose: print("got version from parentdir %s" % ver)
+        if verbose: print(("got version from parentdir %s" % ver))
         return ver
 
-    if verbose: print("got version from default %s" % ver)
+    if verbose: print(("got version from default %s" % ver))
     return default
 
 def get_version(verbose=False):
@@ -740,7 +740,7 @@ class cmd_version(Command):
         pass
     def run(self):
         ver = get_version(verbose=True)
-        print("Version is currently: %s" % ver)
+        print(("Version is currently: %s" % ver))
 
 
 class cmd_build(_build):
@@ -750,7 +750,7 @@ class cmd_build(_build):
         # now locate _version.py in the new build/ directory and replace it
         # with an updated value
         target_versionfile = os.path.join(self.build_lib, versionfile_build)
-        print("UPDATING %s" % target_versionfile)
+        print(("UPDATING %s" % target_versionfile))
         os.unlink(target_versionfile)
         f = open(target_versionfile, "w")
         f.write(SHORT_VERSION_PY % versions)
@@ -763,7 +763,7 @@ if 'cx_Freeze' in sys.modules:  # cx_freeze enabled?
         def run(self):
             versions = get_versions(verbose=True)
             target_versionfile = versionfile_source
-            print("UPDATING %s" % target_versionfile)
+            print(("UPDATING %s" % target_versionfile))
             os.unlink(target_versionfile)
             f = open(target_versionfile, "w")
             f.write(SHORT_VERSION_PY % versions)
@@ -791,7 +791,7 @@ class cmd_sdist(_sdist):
         # now locate _version.py in the new base_dir directory (remembering
         # that it may be a hardlink) and replace it with an updated value
         target_versionfile = os.path.join(base_dir, versionfile_source)
-        print("UPDATING %s" % target_versionfile)
+        print(("UPDATING %s" % target_versionfile))
         os.unlink(target_versionfile)
         f = open(target_versionfile, "w")
         f.write(SHORT_VERSION_PY % self._versioneer_generated_versions)
@@ -812,7 +812,7 @@ class cmd_update_files(Command):
     def finalize_options(self):
         pass
     def run(self):
-        print(" creating %s" % versionfile_source)
+        print((" creating %s" % versionfile_source))
         f = open(versionfile_source, "w")
         f.write(LONG_VERSION_PY % {"DOLLAR": "$",
                                    "TAG_PREFIX": tag_prefix,
@@ -827,12 +827,12 @@ class cmd_update_files(Command):
         except EnvironmentError:
             old = ""
         if INIT_PY_SNIPPET not in old:
-            print(" appending to %s" % ipy)
+            print((" appending to %s" % ipy))
             f = open(ipy, "a")
             f.write(INIT_PY_SNIPPET)
             f.close()
         else:
-            print(" %s unmodified" % ipy)
+            print((" %s unmodified" % ipy))
 
         # Make sure both the top-level "versioneer.py" and versionfile_source
         # (PKG/_version.py, used by runtime code) are in MANIFEST.in, so
@@ -859,8 +859,8 @@ class cmd_update_files(Command):
         else:
             print(" 'versioneer.py' already in MANIFEST.in")
         if versionfile_source not in simple_includes:
-            print(" appending versionfile_source ('%s') to MANIFEST.in" %
-                  versionfile_source)
+            print((" appending versionfile_source ('%s') to MANIFEST.in" %
+                  versionfile_source))
             f = open(manifest_in, "a")
             f.write("include %s\n" % versionfile_source)
             f.close()


### PR DESCRIPTION
This is my ancient port (from about 2016) to python3.5+.  It needs some work to reconcile the changes upstream (and to clean up some of the dirty hacks I did to get it functional), but at least some parts of it should help other efforts to get this to python3 (and it *may* be a better starting point than the last 2.7 release).

Note that it does *not* use `six`, as I had no need to run on python2 after the migration.  Instead, I used 2to3 (from python3.4), which broke things terribly, and then spent far too much time sorting out what that *stupid* script broke. 